### PR TITLE
Format codebase with Black and remove unused imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,3 @@
-
 from .piper_msgs.msg_v1 import *
 from .protocol.protocol_v1 import *
 from .hardware_port.can_encapsulation import C_STD_CAN
@@ -6,17 +5,16 @@ from .base.piper_base import C_PiperBase
 from .interface.piper_interface import C_PiperInterface
 
 __all__ = [
-    'C_PiperParserBase',
-    'C_PiperParserV1',
-    'ArmMsgEndPoseFeedBack',
-    'PiperMessage',
-    'CanIDPiper',
-    'ArmMsgJointFeedBack',
-    'ArmMsgType',
-    'ArmMsgStatus',
-    'ArmMsgGripperFeedBack',
-    'C_STD_CAN',
-    'C_PiperBase',
-    'C_PiperInterface'
+    "C_PiperParserBase",
+    "C_PiperParserV1",
+    "ArmMsgEndPoseFeedBack",
+    "PiperMessage",
+    "CanIDPiper",
+    "ArmMsgJointFeedBack",
+    "ArmMsgType",
+    "ArmMsgStatus",
+    "ArmMsgGripperFeedBack",
+    "C_STD_CAN",
+    "C_PiperBase",
+    "C_PiperInterface",
 ]
-

--- a/base/__init__.py
+++ b/base/__init__.py
@@ -1,7 +1,3 @@
-
 from .piper_base import C_PiperBase
 
-__all__ = [
-    'C_PiperBase'
-]
-
+__all__ = ["C_PiperBase"]

--- a/base/piper_base.py
+++ b/base/piper_base.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
-#机械臂控制base
+# 机械臂控制base
 
 import can
 from can.message import Message
@@ -13,9 +13,10 @@ from typing import Type
 from ..interface.piper_interface import C_PiperInterface
 from ..hardware_port.can_encapsulation import C_STD_CAN
 
+
 class C_PiperBase(C_PiperInterface):
     def __init__(self, can_name: str = "can0") -> None:
         super().__init__(can_name)
-    
-    def Connect(self, can_name:str):
+
+    def Connect(self, can_name: str):
         return self.ConnectPort(can_name)

--- a/base/piper_base.py
+++ b/base/piper_base.py
@@ -3,15 +3,8 @@
 
 # 机械臂控制base
 
-import can
-from can.message import Message
-from typing import (
-    Optional,
-)
-from typing import Type
 
 from ..interface.piper_interface import C_PiperInterface
-from ..hardware_port.can_encapsulation import C_STD_CAN
 
 
 class C_PiperBase(C_PiperInterface):

--- a/demo/piper_joint_ctrl.py
+++ b/demo/piper_joint_ctrl.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 # 注意demo无法直接运行，需要pip安装sdk后才能运行
-from typing import (
-    Optional,
-)
 import time
 from piper_sdk import *
 
@@ -58,7 +55,6 @@ if __name__ == "__main__":
     count = 0
     while True:
         print(piper.GetArmStatus())
-        import time
 
         count = count + 1
         # print(count)

--- a/demo/piper_joint_ctrl.py
+++ b/demo/piper_joint_ctrl.py
@@ -7,10 +7,11 @@ from typing import (
 import time
 from piper_sdk import *
 
-def enable_fun(piper:C_PiperInterface):
-    '''
+
+def enable_fun(piper: C_PiperInterface):
+    """
     使能机械臂并检测使能状态,尝试5s,如果使能超时则退出程序
-    '''
+    """
     enable_flag = False
     # 设置超时时间（秒）
     timeout = 5
@@ -20,15 +21,17 @@ def enable_fun(piper:C_PiperInterface):
     while not (enable_flag):
         elapsed_time = time.time() - start_time
         print("--------------------")
-        enable_flag = piper.GetArmLowSpdInfoMsgs().motor_1.foc_status.driver_enable_status and \
-            piper.GetArmLowSpdInfoMsgs().motor_2.foc_status.driver_enable_status and \
-            piper.GetArmLowSpdInfoMsgs().motor_3.foc_status.driver_enable_status and \
-            piper.GetArmLowSpdInfoMsgs().motor_4.foc_status.driver_enable_status and \
-            piper.GetArmLowSpdInfoMsgs().motor_5.foc_status.driver_enable_status and \
-            piper.GetArmLowSpdInfoMsgs().motor_6.foc_status.driver_enable_status
-        print("使能状态:",enable_flag)
+        enable_flag = (
+            piper.GetArmLowSpdInfoMsgs().motor_1.foc_status.driver_enable_status
+            and piper.GetArmLowSpdInfoMsgs().motor_2.foc_status.driver_enable_status
+            and piper.GetArmLowSpdInfoMsgs().motor_3.foc_status.driver_enable_status
+            and piper.GetArmLowSpdInfoMsgs().motor_4.foc_status.driver_enable_status
+            and piper.GetArmLowSpdInfoMsgs().motor_5.foc_status.driver_enable_status
+            and piper.GetArmLowSpdInfoMsgs().motor_6.foc_status.driver_enable_status
+        )
+        print("使能状态:", enable_flag)
         piper.EnableArm(7)
-        piper.GripperCtrl(0,1000,0x01, 0)
+        piper.GripperCtrl(0, 1000, 0x01, 0)
         print("--------------------")
         # 检查是否超过超时时间
         if elapsed_time > timeout:
@@ -38,9 +41,10 @@ def enable_fun(piper:C_PiperInterface):
             break
         time.sleep(1)
         pass
-    if(elapsed_time_flag):
+    if elapsed_time_flag:
         print("程序自动使能超时,退出程序")
         exit(0)
+
 
 if __name__ == "__main__":
     piper = C_PiperInterface("can0")
@@ -48,33 +52,34 @@ if __name__ == "__main__":
     piper.EnableArm(7)
     enable_fun(piper=piper)
     # piper.DisableArm(7)
-    piper.GripperCtrl(0,1000,0x01, 0)
-    factor = 57324.840764 #1000*180/3.14
-    position = [0,0,0,0,0,0,0]
+    piper.GripperCtrl(0, 1000, 0x01, 0)
+    factor = 57324.840764  # 1000*180/3.14
+    position = [0, 0, 0, 0, 0, 0, 0]
     count = 0
     while True:
         print(piper.GetArmStatus())
         import time
-        count  = count + 1
+
+        count = count + 1
         # print(count)
-        if(count == 0):
+        if count == 0:
             print("1-----------")
-            position = [0,0,0,0,0,0,0]
-        elif(count == 500):
+            position = [0, 0, 0, 0, 0, 0, 0]
+        elif count == 500:
             print("2-----------")
-            position = [0.2,0.2,-0.2,0.3,-0.2,0.5,0.08]
-        elif(count == 1000):
+            position = [0.2, 0.2, -0.2, 0.3, -0.2, 0.5, 0.08]
+        elif count == 1000:
             print("1-----------")
-            position = [0,0,0,0,0,0,0]
+            position = [0, 0, 0, 0, 0, 0, 0]
             count = 0
-        
-        joint_0 = round(position[0]*factor)
-        joint_1 = round(position[1]*factor)
-        joint_2 = round(position[2]*factor)
-        joint_3 = round(position[3]*factor)
-        joint_4 = round(position[4]*factor)
-        joint_5 = round(position[5]*factor)
-        joint_6 = round(position[6]*1000*1000)
+
+        joint_0 = round(position[0] * factor)
+        joint_1 = round(position[1] * factor)
+        joint_2 = round(position[2] * factor)
+        joint_3 = round(position[3] * factor)
+        joint_4 = round(position[4] * factor)
+        joint_5 = round(position[5] * factor)
+        joint_6 = round(position[6] * 1000 * 1000)
         # piper.MotionCtrl_1()
         piper.MotionCtrl_2(0x01, 0x01, 50, 0x00)
         piper.JointCtrl(joint_0, joint_1, joint_2, joint_3, joint_4, joint_5)

--- a/demo/read_joint_state.py
+++ b/demo/read_joint_state.py
@@ -2,9 +2,6 @@
 # -*-coding:utf8-*-
 # 注意demo无法直接运行，需要pip安装sdk后才能运行
 # 读取机械臂消息并打印,需要先安装piper_sdk
-from typing import (
-    Optional,
-)
 from piper_sdk import *
 
 # 测试代码

--- a/demo/read_joint_state.py
+++ b/demo/read_joint_state.py
@@ -13,6 +13,7 @@ if __name__ == "__main__":
     piper.ConnectPort()
     while True:
         import time
+
         # a.SearchMotorMaxAngleSpdAccLimit(1, 1)
         # a.ArmParamEnquiryAndConfig(1,0,2,0,3)
         # a.GripperCtrl(50000,1500,0x01)

--- a/hardware_port/__init__.py
+++ b/hardware_port/__init__.py
@@ -1,9 +1,5 @@
-
 from .can_encapsulation import C_STD_CAN
 
 # 导入 hardware_port 子模块
 
-__all__ = [
-    'C_STD_CAN'
-]
-
+__all__ = ["C_STD_CAN"]

--- a/hardware_port/can_encapsulation.py
+++ b/hardware_port/can_encapsulation.py
@@ -4,17 +4,13 @@
 import can
 from can.message import Message
 import time
-from threading import Timer
 import subprocess
 from typing import (
     Callable,
-    Iterator,
     Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-    cast,
+)
+from typing_extensions import (
+    Literal,
 )
 
 
@@ -238,8 +234,8 @@ count = 0
 
 def check_and_convert_to_negative(value):
     # 定义 32 位整数的范围
-    INT32_MAX = 2**31 - 1
-    INT32_MIN = -(2**31)
+    # INT32_MAX = 2**31 - 1
+    # INT32_MIN = -(2**31)
 
     # 判断是否超出范围
     # if value > INT32_MAX or value < INT32_MIN:
@@ -252,12 +248,6 @@ def check_and_convert_to_negative(value):
         value -= 0x100000000  # 如果符号位为 1，表示负数，需要减去 2^32
 
     return value
-
-
-from typing_extensions import (
-    Literal,
-    LiteralString,
-)
 
 
 def ConvertBytesToInt(

--- a/interface/__init__.py
+++ b/interface/__init__.py
@@ -1,7 +1,3 @@
-
 from .piper_interface import *
 
-__all__ = [
-    'C_PiperInterface'
-]
-
+__all__ = ["C_PiperInterface"]

--- a/interface/piper_interface.py
+++ b/interface/piper_interface.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
-#机械臂使用接口
+# 机械臂使用接口
 import time
 import can
 from can.message import Message
@@ -17,244 +17,287 @@ from ..hardware_port.can_encapsulation import C_STD_CAN
 from ..protocol.protocol_v1 import C_PiperParserBase, C_PiperParserV1
 from ..piper_msgs.msg_v1 import *
 
-class C_PiperInterface():
-    '''
+
+class C_PiperInterface:
+    """
     Piper机械臂接口
-    '''
-    class ArmStatus():
-        '''
+    """
+
+    class ArmStatus:
+        """
         机械臂状态二次封装类,增加时间戳
-        '''
+        """
+
         def __init__(self):
             # 将time_stamp和arm_status定义为实例变量
             self.time_stamp: float = 0
             self.arm_status = ArmMsgStatus()
-        def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"{self.arm_status}\n")
 
-    class ArmEndPose():
-        '''
+        def __str__(self):
+            return f"time stamp:{self.time_stamp}\n" f"{self.arm_status}\n"
+
+    class ArmEndPose:
+        """
         机械臂末端姿态二次封装类,增加时间戳
-        '''
+        """
+
         def __init__(self):
-            self.time_stamp: float=0
-            self.end_pose=ArmMsgEndPoseFeedBack()
+            self.time_stamp: float = 0
+            self.end_pose = ArmMsgEndPoseFeedBack()
+
         def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"{self.end_pose}\n")
-    
-    class ArmJoint():
-        '''
+            return f"time stamp:{self.time_stamp}\n" f"{self.end_pose}\n"
+
+    class ArmJoint:
+        """
         机械臂关节角度和夹爪二次封装类,将夹爪和关节角度信息放在一起,增加时间戳
-        '''
+        """
+
         def __init__(self):
-            self.time_stamp: float=0
-            self.joint_state=ArmMsgJointFeedBack()
+            self.time_stamp: float = 0
+            self.joint_state = ArmMsgJointFeedBack()
+
         def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"{self.joint_state}\n")
-    
-    class ArmGripper():
-        '''
+            return f"time stamp:{self.time_stamp}\n" f"{self.joint_state}\n"
+
+    class ArmGripper:
+        """
         机械臂关节角度和夹爪二次封装类,将夹爪和关节角度信息放在一起,增加时间戳
-        '''
+        """
+
         def __init__(self):
-            self.time_stamp: float=0
-            self.gripper_state=ArmMsgGripperFeedBack()
+            self.time_stamp: float = 0
+            self.gripper_state = ArmMsgGripperFeedBack()
+
         def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"{self.gripper_state}\n")
-    
-    class ArmMotorDriverInfoHighSpd():
-        '''
+            return f"time stamp:{self.time_stamp}\n" f"{self.gripper_state}\n"
+
+    class ArmMotorDriverInfoHighSpd:
+        """
         机械臂电机驱动高速反馈信息
-        '''
+        """
+
         def __init__(self):
-            self.time_stamp: float=0
-            self.motor_1=ArmHighSpdFeedback()
-            self.motor_2=ArmHighSpdFeedback()
-            self.motor_3=ArmHighSpdFeedback()
-            self.motor_4=ArmHighSpdFeedback()
-            self.motor_5=ArmHighSpdFeedback()
-            self.motor_6=ArmHighSpdFeedback()
+            self.time_stamp: float = 0
+            self.motor_1 = ArmHighSpdFeedback()
+            self.motor_2 = ArmHighSpdFeedback()
+            self.motor_3 = ArmHighSpdFeedback()
+            self.motor_4 = ArmHighSpdFeedback()
+            self.motor_5 = ArmHighSpdFeedback()
+            self.motor_6 = ArmHighSpdFeedback()
+
         def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"motor_1:{self.motor_1}\n"
-                    f"motor_2:{self.motor_2}\n"
-                    f"motor_3:{self.motor_3}\n"
-                    f"motor_4:{self.motor_4}\n"
-                    f"motor_5:{self.motor_5}\n"
-                    f"motor_6:{self.motor_6}\n")
-    
-    class ArmMotorDriverInfoLowSpd():
-        '''
+            return (
+                f"time stamp:{self.time_stamp}\n"
+                f"motor_1:{self.motor_1}\n"
+                f"motor_2:{self.motor_2}\n"
+                f"motor_3:{self.motor_3}\n"
+                f"motor_4:{self.motor_4}\n"
+                f"motor_5:{self.motor_5}\n"
+                f"motor_6:{self.motor_6}\n"
+            )
+
+    class ArmMotorDriverInfoLowSpd:
+        """
         机械臂电机驱动低速反馈信息
-        '''
+        """
+
         def __init__(self):
-            self.time_stamp: float=0
-            self.motor_1=ArmLowSpdFeedback()
-            self.motor_2=ArmLowSpdFeedback()
-            self.motor_3=ArmLowSpdFeedback()
-            self.motor_4=ArmLowSpdFeedback()
-            self.motor_5=ArmLowSpdFeedback()
-            self.motor_6=ArmLowSpdFeedback()
+            self.time_stamp: float = 0
+            self.motor_1 = ArmLowSpdFeedback()
+            self.motor_2 = ArmLowSpdFeedback()
+            self.motor_3 = ArmLowSpdFeedback()
+            self.motor_4 = ArmLowSpdFeedback()
+            self.motor_5 = ArmLowSpdFeedback()
+            self.motor_6 = ArmLowSpdFeedback()
+
         def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"motor_1:{self.motor_1}\n"
-                    f"motor_2:{self.motor_2}\n"
-                    f"motor_3:{self.motor_3}\n"
-                    f"motor_4:{self.motor_4}\n"
-                    f"motor_5:{self.motor_5}\n"
-                    f"motor_6:{self.motor_6}\n")
-    
-    class ArmMotorAngleLimitAndMaxVel():
-        '''
+            return (
+                f"time stamp:{self.time_stamp}\n"
+                f"motor_1:{self.motor_1}\n"
+                f"motor_2:{self.motor_2}\n"
+                f"motor_3:{self.motor_3}\n"
+                f"motor_4:{self.motor_4}\n"
+                f"motor_5:{self.motor_5}\n"
+                f"motor_6:{self.motor_6}\n"
+            )
+
+    class ArmMotorAngleLimitAndMaxVel:
+        """
         当前电机限制角度/最大速度
-        '''
-        def __init__(self):
-            self.time_stamp: float=0
-            self.current_motor_angle_limit_max_vel=ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd()
-        def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"current_motor_angle_limit_max_vel:{self.current_motor_angle_limit_max_vel}\n")
+        """
 
-    class CurrentEndVelAndAccParam():
-        '''
+        def __init__(self):
+            self.time_stamp: float = 0
+            self.current_motor_angle_limit_max_vel = (
+                ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd()
+            )
+
+        def __str__(self):
+            return (
+                f"time stamp:{self.time_stamp}\n"
+                f"current_motor_angle_limit_max_vel:{self.current_motor_angle_limit_max_vel}\n"
+            )
+
+    class CurrentEndVelAndAccParam:
+        """
         当前末端速度/加速度参数
-        '''
-        def __init__(self):
-            self.time_stamp: float=0
-            self.current_end_vel_acc_param=ArmMsgFeedbackCurrentEndVelAccParam()
-        def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"current_end_vel_acc_param:{self.current_end_vel_acc_param}\n")
-    
-    class CrashProtectionLevelFeedback():
-        '''
-        碰撞防护等级设置反馈指令
-        '''
-        def __init__(self):
-            self.time_stamp: float=0
-            self.crash_protection_level_feedback=ArmMsgCrashProtectionRatingFeedback()
-        def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"crash_protection_level_feedback:{self.crash_protection_level_feedback}\n")
-    
-    class CurrentMotorMaxAccLimit():
-        '''
-        反馈当前电机最大加速度限制
-        '''
-        def __init__(self):
-            self.time_stamp: float=0
-            self.current_motor_max_acc_limit=ArmMsgFeedbackCurrentMotorMaxAccLimit()
-        def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"current_motor_max_acc_limit:{self.current_motor_max_acc_limit}\n")
+        """
 
-    class ArmJointCtrl():
-        '''
+        def __init__(self):
+            self.time_stamp: float = 0
+            self.current_end_vel_acc_param = ArmMsgFeedbackCurrentEndVelAccParam()
+
+        def __str__(self):
+            return (
+                f"time stamp:{self.time_stamp}\n"
+                f"current_end_vel_acc_param:{self.current_end_vel_acc_param}\n"
+            )
+
+    class CrashProtectionLevelFeedback:
+        """
+        碰撞防护等级设置反馈指令
+        """
+
+        def __init__(self):
+            self.time_stamp: float = 0
+            self.crash_protection_level_feedback = ArmMsgCrashProtectionRatingFeedback()
+
+        def __str__(self):
+            return (
+                f"time stamp:{self.time_stamp}\n"
+                f"crash_protection_level_feedback:{self.crash_protection_level_feedback}\n"
+            )
+
+    class CurrentMotorMaxAccLimit:
+        """
+        反馈当前电机最大加速度限制
+        """
+
+        def __init__(self):
+            self.time_stamp: float = 0
+            self.current_motor_max_acc_limit = ArmMsgFeedbackCurrentMotorMaxAccLimit()
+
+        def __str__(self):
+            return (
+                f"time stamp:{self.time_stamp}\n"
+                f"current_motor_max_acc_limit:{self.current_motor_max_acc_limit}\n"
+            )
+
+    class ArmJointCtrl:
+        """
         机械臂关节角度和夹爪二次封装类,将夹爪和关节角度信息放在一起,增加时间戳
         这个是主臂发送的消息，用来读取发送给从臂的目标值
-        '''
+        """
+
         def __init__(self):
-            self.time_stamp: float=0
-            self.joint_ctrl=ArmMsgJointCtrl()
+            self.time_stamp: float = 0
+            self.joint_ctrl = ArmMsgJointCtrl()
+
         def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"{self.joint_ctrl}\n")
-    
-    class ArmGripperCtrl():
-        '''
+            return f"time stamp:{self.time_stamp}\n" f"{self.joint_ctrl}\n"
+
+    class ArmGripperCtrl:
+        """
         机械臂关节角度和夹爪二次封装类,将夹爪和关节角度信息放在一起,增加时间戳
         这个是主臂发送的消息，用来读取发送给从臂的目标值
-        '''
+        """
+
         def __init__(self):
-            self.time_stamp: float=0
-            self.gripper_ctrl=ArmMsgGripperCtrl()
+            self.time_stamp: float = 0
+            self.gripper_ctrl = ArmMsgGripperCtrl()
+
         def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"{self.gripper_ctrl}\n")
-    
-    class ArmCtrlCode_151():
-        '''
+            return f"time stamp:{self.time_stamp}\n" f"{self.gripper_ctrl}\n"
+
+    class ArmCtrlCode_151:
+        """
         机械臂发送控制指令0x151的消息接收,由主臂发送
-        '''
+        """
+
         def __init__(self):
-            self.time_stamp: float=0
-            self.ctrl_151=ArmMsgMotionCtrl_2()
+            self.time_stamp: float = 0
+            self.ctrl_151 = ArmMsgMotionCtrl_2()
+
         def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"{self.ctrl_151}\n")
-    
-    class AllCurrentMotorMaxAccLimit():
+            return f"time stamp:{self.time_stamp}\n" f"{self.ctrl_151}\n"
+
+    class AllCurrentMotorMaxAccLimit:
         def __init__(self):
-            self.time_stamp: float=0
-            self.all_motor_max_acc_limit=ArmMsgFeedbackAllCurrentMotorMaxAccLimit()
+            self.time_stamp: float = 0
+            self.all_motor_max_acc_limit = ArmMsgFeedbackAllCurrentMotorMaxAccLimit()
+
         def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"{self.all_motor_max_acc_limit}\n")
-    
-    class AllCurrentMotorAngleLimitMaxSpd():
+            return f"time stamp:{self.time_stamp}\n" f"{self.all_motor_max_acc_limit}\n"
+
+    class AllCurrentMotorAngleLimitMaxSpd:
         def __init__(self):
-            self.time_stamp: float=0
-            self.all_motor_angle_limit_max_spd=ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd()
+            self.time_stamp: float = 0
+            self.all_motor_angle_limit_max_spd = (
+                ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd()
+            )
+
         def __str__(self):
-            return (f"time stamp:{self.time_stamp}\n"
-                    f"{self.all_motor_angle_limit_max_spd}\n")
-    
-    class ArmTimeStamp():
-        '''
+            return (
+                f"time stamp:{self.time_stamp}\n"
+                f"{self.all_motor_angle_limit_max_spd}\n"
+            )
+
+    class ArmTimeStamp:
+        """
         机械臂时间戳
-        '''
+        """
+
         def __init__(self):
-            self.time_stamp_arm_status:float=0
-            self.time_stamp_end_pose_1:float=0
-            self.time_stamp_end_pose_2:float=0
-            self.time_stamp_end_pose_3:float=0
-            self.time_stamp_joint_12:float=0
-            self.time_stamp_joint_34:float=0
-            self.time_stamp_joint_56:float=0
-            self.time_stamp_motor_high_spd_1:float=0
-            self.time_stamp_motor_high_spd_2:float=0
-            self.time_stamp_motor_high_spd_3:float=0
-            self.time_stamp_motor_high_spd_4:float=0
-            self.time_stamp_motor_high_spd_5:float=0
-            self.time_stamp_motor_high_spd_6:float=0
-            self.time_stamp_motor_low_spd_1:float=0
-            self.time_stamp_motor_low_spd_2:float=0
-            self.time_stamp_motor_low_spd_3:float=0
-            self.time_stamp_motor_low_spd_4:float=0
-            self.time_stamp_motor_low_spd_5:float=0
-            self.time_stamp_motor_low_spd_6:float=0
-            self.time_stamp_joint_ctrl_12:float=0
-            self.time_stamp_joint_ctrl_34:float=0
-            self.time_stamp_joint_ctrl_56:float=0
-            self.time_stamp_motor_max_acc_limit_1=0
-            self.time_stamp_motor_max_acc_limit_2=0
-            self.time_stamp_motor_max_acc_limit_3=0
-            self.time_stamp_motor_max_acc_limit_4=0
-            self.time_stamp_motor_max_acc_limit_5=0
-            self.time_stamp_motor_max_acc_limit_6=0
-            self.time_stamp_motor_angle_limit_max_spd_1=0
-            self.time_stamp_motor_angle_limit_max_spd_2=0
-            self.time_stamp_motor_angle_limit_max_spd_3=0
-            self.time_stamp_motor_angle_limit_max_spd_4=0
-            self.time_stamp_motor_angle_limit_max_spd_5=0
-            self.time_stamp_motor_angle_limit_max_spd_6=0
-    
-    def __init__(self, can_name:str="can0") -> None:
-        self.can_channel_name:str
+            self.time_stamp_arm_status: float = 0
+            self.time_stamp_end_pose_1: float = 0
+            self.time_stamp_end_pose_2: float = 0
+            self.time_stamp_end_pose_3: float = 0
+            self.time_stamp_joint_12: float = 0
+            self.time_stamp_joint_34: float = 0
+            self.time_stamp_joint_56: float = 0
+            self.time_stamp_motor_high_spd_1: float = 0
+            self.time_stamp_motor_high_spd_2: float = 0
+            self.time_stamp_motor_high_spd_3: float = 0
+            self.time_stamp_motor_high_spd_4: float = 0
+            self.time_stamp_motor_high_spd_5: float = 0
+            self.time_stamp_motor_high_spd_6: float = 0
+            self.time_stamp_motor_low_spd_1: float = 0
+            self.time_stamp_motor_low_spd_2: float = 0
+            self.time_stamp_motor_low_spd_3: float = 0
+            self.time_stamp_motor_low_spd_4: float = 0
+            self.time_stamp_motor_low_spd_5: float = 0
+            self.time_stamp_motor_low_spd_6: float = 0
+            self.time_stamp_joint_ctrl_12: float = 0
+            self.time_stamp_joint_ctrl_34: float = 0
+            self.time_stamp_joint_ctrl_56: float = 0
+            self.time_stamp_motor_max_acc_limit_1 = 0
+            self.time_stamp_motor_max_acc_limit_2 = 0
+            self.time_stamp_motor_max_acc_limit_3 = 0
+            self.time_stamp_motor_max_acc_limit_4 = 0
+            self.time_stamp_motor_max_acc_limit_5 = 0
+            self.time_stamp_motor_max_acc_limit_6 = 0
+            self.time_stamp_motor_angle_limit_max_spd_1 = 0
+            self.time_stamp_motor_angle_limit_max_spd_2 = 0
+            self.time_stamp_motor_angle_limit_max_spd_3 = 0
+            self.time_stamp_motor_angle_limit_max_spd_4 = 0
+            self.time_stamp_motor_angle_limit_max_spd_5 = 0
+            self.time_stamp_motor_angle_limit_max_spd_6 = 0
+
+    def __init__(self, can_name: str = "can0") -> None:
+        self.can_channel_name: str
         if isinstance(can_name, str):
             self.can_channel_name = can_name
         else:
             raise IndexError("C_PiperBase input can name is not str type")
         # print("----")
-        self.arm_can=C_STD_CAN(can_name, "socketcan", 1000000, True, True, self.ParseCANFrame)
+        self.arm_can = C_STD_CAN(
+            can_name, "socketcan", 1000000, True, True, self.ParseCANFrame
+        )
         # self.rx_original_msg:Optional[Message]
         # 协议解析
         self.parser: Type[C_PiperParserBase] = C_PiperParserV1()
-        self.__arm_time_stamp = self.ArmTimeStamp()#时间戳
+        self.__arm_time_stamp = self.ArmTimeStamp()  # 时间戳
         # 二次封装数据类型
         self.__arm_status_mtx = threading.Lock()
         self.__arm_status = self.ArmStatus()
@@ -275,7 +318,9 @@ class C_PiperInterface():
         self.__arm_motor_info_low_spd = self.ArmMotorDriverInfoLowSpd()
         # 当前电机限制角度/最大速度
         self.__feedback_current_motor_angle_limit_max_vel_mtx = threading.Lock()
-        self.__feedback_current_motor_angle_limit_max_vel = self.ArmMotorAngleLimitAndMaxVel()
+        self.__feedback_current_motor_angle_limit_max_vel = (
+            self.ArmMotorAngleLimitAndMaxVel()
+        )
 
         self.__feedback_current_end_vel_acc_param_mtx = threading.Lock()
         self.__feedback_current_end_vel_acc_param = self.CurrentEndVelAndAccParam()
@@ -288,30 +333,33 @@ class C_PiperInterface():
 
         self.__arm_joint_ctrl_msgs_mtx = threading.Lock()
         self.__arm_joint_ctrl_msgs = self.ArmJointCtrl()
-        
+
         self.__arm_gripper_ctrl_msgs_mtx = threading.Lock()
         self.__arm_gripper_ctrl_msgs = self.ArmGripperCtrl()
 
         self.__arm_ctrl_code_151_mtx = threading.Lock()
         self.__arm_ctrl_code_151 = self.ArmCtrlCode_151()
-        
+
         self.__arm_all_motor_max_acc_limit_mtx = threading.Lock()
         self.__arm_all_motor_max_acc_limit = self.AllCurrentMotorMaxAccLimit()
-        
+
         self.__arm_all_motor_angle_limit_max_spd_mtx = threading.Lock()
-        self.__arm_all_motor_angle_limit_max_spd = self.AllCurrentMotorAngleLimitMaxSpd()
-    
+        self.__arm_all_motor_angle_limit_max_spd = (
+            self.AllCurrentMotorAngleLimitMaxSpd()
+        )
+
     def ConnectPort(self):
         # self.arm_can = C_STD_CAN(can_name, "socketcan", 500000, True, True, self.ParseCANFrame)
         def ReadCan():
             while True:
                 self.arm_can.ReadCanMessage()
+
         can_deal_th = threading.Thread(target=ReadCan)
         can_deal_th.daemon = True
         can_deal_th.start()
         self.SearchAllMotorMaxAngleSpd()
         self.SearchAllMotorMaxAccLimit()
-    
+
     def ParseCANFrame(self, rx_message: Optional[can.Message]):
         """can协议解析函数
 
@@ -321,7 +369,7 @@ class C_PiperInterface():
         msg = PiperMessage()
         receive_flag = self.parser.DecodeMessage(rx_message, msg)
         # print(receive_flag)
-        if(receive_flag):
+        if receive_flag:
             self.UpdateArmStatus(msg)
             self.UpdateArmEndPoseState(msg)
             self.UpdateArmJointState(msg)
@@ -339,14 +387,15 @@ class C_PiperInterface():
             self.UpdateArmJointCtrl(msg)
             self.UpdateArmGripperCtrl(msg)
             self.UpdateArmCtrlCode151(msg)
-    
-    def JudgeExsitedArm(self, can_id:int):
+
+    def JudgeExsitedArm(self, can_id: int):
         """判断当前can socket是否有指定的机械臂设备,通过can id筛选
 
         Args:
             can_id (int): 输入can 🆔
         """
         pass
+
     # 获取反馈值------------------------------------------------------------------------------------------------------
     def GetArmStatus(self):
         with self.__arm_status_mtx:
@@ -359,27 +408,27 @@ class C_PiperInterface():
     def GetArmJointMsgs(self):
         with self.__arm_joint_msgs_mtx:
             return self.__arm_joint_msgs
-    
+
     def GetArmGripperMsgs(self):
         with self.__arm_gripper_msgs_mtx:
             return self.__arm_gripper_msgs
-    
+
     def GetArmHighSpdInfoMsgs(self):
         with self.__arm_motor_info_high_spd_mtx:
             return self.__arm_motor_info_high_spd
-    
+
     def GetArmLowSpdInfoMsgs(self):
         with self.__arm_motor_info_low_spd_mtx:
             return self.__arm_motor_info_low_spd
-    
+
     def GetCurrentMotorAngleLimitMaxVel(self):
         with self.__feedback_current_motor_angle_limit_max_vel_mtx:
             return self.__feedback_current_motor_angle_limit_max_vel
-    
+
     def GetCurrentEndVelAndAccParam(self):
         with self.__feedback_current_end_vel_acc_param_mtx:
             return self.__feedback_current_end_vel_acc_param
-    
+
     def GetCrashProtectionLevelFeedback(self):
         with self.__feedback_crash_protection_level_mtx:
             return self.__feedback_crash_protection_level
@@ -387,513 +436,793 @@ class C_PiperInterface():
     def GetCurrentMotorMaxAccLimit(self):
         with self.__feedback_current_motor_max_acc_limit_mtx:
             return self.__feedback_current_motor_max_acc_limit
-    
+
     def GetArmJointCtrl(self):
         with self.__arm_joint_ctrl_msgs_mtx:
             return self.__arm_joint_ctrl_msgs
-    
+
     def GetArmGripperCtrl(self):
         with self.__arm_gripper_ctrl_msgs_mtx:
             return self.__arm_gripper_ctrl_msgs
-    
+
     def GetArmCtrlCode151(self):
         with self.__arm_ctrl_code_151_mtx:
             return self.__arm_ctrl_code_151
-    
+
     def GetAllMotorMaxAccLimit(self):
         with self.__arm_all_motor_max_acc_limit_mtx:
             return self.__arm_all_motor_max_acc_limit
-    
+
     def GetAllMotorAngleLimitMaxSpd(self):
         with self.__arm_all_motor_angle_limit_max_spd_mtx:
             return self.__arm_all_motor_angle_limit_max_spd
+
     # 发送控制值-------------------------------------------------------------------------------------------------------
 
     # 接收反馈函数------------------------------------------------------------------------------------------------------
-    def UpdateArmStatus(self, msg:PiperMessage):
+    def UpdateArmStatus(self, msg: PiperMessage):
         """更新机械臂状态
 
         Args:
             msg (PiperMessage): 输入为机械臂消息汇总
         """
         with self.__arm_status_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgStatusFeedback):
-                self.__arm_status.time_stamp = time.time_ns()/ 1_000_000_000
+            if msg.type_ == ArmMsgType.PiperMsgStatusFeedback:
+                self.__arm_status.time_stamp = time.time_ns() / 1_000_000_000
                 self.__arm_status.arm_status.ctrl_mode = msg.arm_status_msgs.ctrl_mode
                 self.__arm_status.arm_status.arm_status = msg.arm_status_msgs.arm_status
                 self.__arm_status.arm_status.mode_feed = msg.arm_status_msgs.mode_feed
-                self.__arm_status.arm_status.teach_status = msg.arm_status_msgs.teach_status
-                self.__arm_status.arm_status.motion_status = msg.arm_status_msgs.motion_status
-                self.__arm_status.arm_status.trajectory_num = msg.arm_status_msgs.trajectory_num
+                self.__arm_status.arm_status.teach_status = (
+                    msg.arm_status_msgs.teach_status
+                )
+                self.__arm_status.arm_status.motion_status = (
+                    msg.arm_status_msgs.motion_status
+                )
+                self.__arm_status.arm_status.trajectory_num = (
+                    msg.arm_status_msgs.trajectory_num
+                )
                 self.__arm_status.arm_status.err_code = msg.arm_status_msgs.err_code
             # print(self.__arm_status)
             return self.__arm_status
 
-    def UpdateArmEndPoseState(self, msg:PiperMessage):
+    def UpdateArmEndPoseState(self, msg: PiperMessage):
         """更新末端位姿状态
 
         Args:
             msg (PiperMessage): 输入为机械臂消息汇总
         """
         with self.__arm_end_pose_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgEndPoseFeedback_1):
+            if msg.type_ == ArmMsgType.PiperMsgEndPoseFeedback_1:
                 self.__arm_time_stamp.time_stamp_end_pose_1 = time.time_ns()
                 self.__arm_end_pose.end_pose.X_axis = msg.arm_end_pose.X_axis
                 self.__arm_end_pose.end_pose.Y_axis = msg.arm_end_pose.Y_axis
-            elif(msg.type_ == ArmMsgType.PiperMsgEndPoseFeedback_2):
+            elif msg.type_ == ArmMsgType.PiperMsgEndPoseFeedback_2:
                 self.__arm_time_stamp.time_stamp_end_pose_2 = time.time_ns()
                 self.__arm_end_pose.end_pose.Z_axis = msg.arm_end_pose.Z_axis
                 self.__arm_end_pose.end_pose.RX_axis = msg.arm_end_pose.RX_axis
-            elif(msg.type_ == ArmMsgType.PiperMsgEndPoseFeedback_3):
+            elif msg.type_ == ArmMsgType.PiperMsgEndPoseFeedback_3:
                 self.__arm_time_stamp.time_stamp_end_pose_3 = time.time_ns()
                 self.__arm_end_pose.end_pose.RY_axis = msg.arm_end_pose.RY_axis
                 self.__arm_end_pose.end_pose.RZ_axis = msg.arm_end_pose.RZ_axis
-            self.__arm_end_pose.time_stamp = max(self.__arm_time_stamp.time_stamp_end_pose_1, 
-                                                self.__arm_time_stamp.time_stamp_end_pose_2, 
-                                                self.__arm_time_stamp.time_stamp_end_pose_3) / 1_000_000_000
+            self.__arm_end_pose.time_stamp = (
+                max(
+                    self.__arm_time_stamp.time_stamp_end_pose_1,
+                    self.__arm_time_stamp.time_stamp_end_pose_2,
+                    self.__arm_time_stamp.time_stamp_end_pose_3,
+                )
+                / 1_000_000_000
+            )
             # print(self.__arm_end_pose)
             return self.__arm_end_pose
 
-    def UpdateArmJointState(self, msg:PiperMessage):
+    def UpdateArmJointState(self, msg: PiperMessage):
         """更新关节状态
 
         Args:
             msg (PiperMessage): 输入为机械臂消息汇总
         """
         with self.__arm_joint_msgs_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgJointFeedBack_12):
+            if msg.type_ == ArmMsgType.PiperMsgJointFeedBack_12:
                 self.__arm_time_stamp.time_stamp_joint_12 = time.time_ns()
-                self.__arm_joint_msgs.joint_state.joint_1 = msg.arm_joint_feedback.joint_1
-                self.__arm_joint_msgs.joint_state.joint_2 = msg.arm_joint_feedback.joint_2
-            elif(msg.type_ == ArmMsgType.PiperMsgJointFeedBack_34):
+                self.__arm_joint_msgs.joint_state.joint_1 = (
+                    msg.arm_joint_feedback.joint_1
+                )
+                self.__arm_joint_msgs.joint_state.joint_2 = (
+                    msg.arm_joint_feedback.joint_2
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgJointFeedBack_34:
                 self.__arm_time_stamp.time_stamp_joint_34 = time.time_ns()
-                self.__arm_joint_msgs.joint_state.joint_3 = msg.arm_joint_feedback.joint_3
-                self.__arm_joint_msgs.joint_state.joint_4 = msg.arm_joint_feedback.joint_4
-            elif(msg.type_ == ArmMsgType.PiperMsgJointFeedBack_56):
+                self.__arm_joint_msgs.joint_state.joint_3 = (
+                    msg.arm_joint_feedback.joint_3
+                )
+                self.__arm_joint_msgs.joint_state.joint_4 = (
+                    msg.arm_joint_feedback.joint_4
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgJointFeedBack_56:
                 self.__arm_time_stamp.time_stamp_joint_56 = time.time_ns()
-                self.__arm_joint_msgs.joint_state.joint_5 = msg.arm_joint_feedback.joint_5
-                self.__arm_joint_msgs.joint_state.joint_6 = msg.arm_joint_feedback.joint_6
+                self.__arm_joint_msgs.joint_state.joint_5 = (
+                    msg.arm_joint_feedback.joint_5
+                )
+                self.__arm_joint_msgs.joint_state.joint_6 = (
+                    msg.arm_joint_feedback.joint_6
+                )
             else:
                 pass
             # 更新时间戳，取筛选ID的最新一个
-            self.__arm_joint_msgs.time_stamp = max(self.__arm_time_stamp.time_stamp_joint_12, 
-                                                        self.__arm_time_stamp.time_stamp_joint_34, 
-                                                        self.__arm_time_stamp.time_stamp_joint_56)/ 1_000_000_000
+            self.__arm_joint_msgs.time_stamp = (
+                max(
+                    self.__arm_time_stamp.time_stamp_joint_12,
+                    self.__arm_time_stamp.time_stamp_joint_34,
+                    self.__arm_time_stamp.time_stamp_joint_56,
+                )
+                / 1_000_000_000
+            )
             # print(self.__arm_joint_msgs)
             return self.__arm_joint_msgs
 
-    def UpdateArmGripperState(self, msg:PiperMessage):
+    def UpdateArmGripperState(self, msg: PiperMessage):
         """更新夹爪状态
 
         Args:
             msg (PiperMessage): 输入为机械臂消息汇总
         """
         with self.__arm_gripper_msgs_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgGripperFeedBack):
+            if msg.type_ == ArmMsgType.PiperMsgGripperFeedBack:
                 self.__arm_gripper_msgs.time_stamp = time.time_ns()
-                self.__arm_gripper_msgs.gripper_state.grippers_angle = msg.gripper_feedback.grippers_angle
-                self.__arm_gripper_msgs.gripper_state.grippers_effort = msg.gripper_feedback.grippers_effort
-                self.__arm_gripper_msgs.gripper_state.status_code = msg.gripper_feedback.status_code
+                self.__arm_gripper_msgs.gripper_state.grippers_angle = (
+                    msg.gripper_feedback.grippers_angle
+                )
+                self.__arm_gripper_msgs.gripper_state.grippers_effort = (
+                    msg.gripper_feedback.grippers_effort
+                )
+                self.__arm_gripper_msgs.gripper_state.status_code = (
+                    msg.gripper_feedback.status_code
+                )
             else:
                 pass
             # print(self.__arm_gripper_msgs)
             return self.__arm_gripper_msgs
-    
-    def UpdateDriverInfoHighSpdFeedback(self, msg:PiperMessage):
+
+    def UpdateDriverInfoHighSpdFeedback(self, msg: PiperMessage):
         """更新驱动器信息反馈, 高速
 
         Args:
             msg (PiperMessage): 输入为机械臂消息汇总
         """
         with self.__arm_motor_info_high_spd_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgHighSpdFeed_1):
+            if msg.type_ == ArmMsgType.PiperMsgHighSpdFeed_1:
                 self.__arm_time_stamp.time_stamp_motor_low_spd_1 = time.time_ns()
-                self.__arm_motor_info_high_spd.motor_1.can_id = msg.arm_high_spd_feedback_1.can_id
-                self.__arm_motor_info_high_spd.motor_1.motor_speed = msg.arm_high_spd_feedback_1.motor_speed
-                self.__arm_motor_info_high_spd.motor_1.current = msg.arm_high_spd_feedback_1.current
-                self.__arm_motor_info_high_spd.motor_1.pos = msg.arm_high_spd_feedback_1.pos
-            elif(msg.type_ == ArmMsgType.PiperMsgHighSpdFeed_2):
+                self.__arm_motor_info_high_spd.motor_1.can_id = (
+                    msg.arm_high_spd_feedback_1.can_id
+                )
+                self.__arm_motor_info_high_spd.motor_1.motor_speed = (
+                    msg.arm_high_spd_feedback_1.motor_speed
+                )
+                self.__arm_motor_info_high_spd.motor_1.current = (
+                    msg.arm_high_spd_feedback_1.current
+                )
+                self.__arm_motor_info_high_spd.motor_1.pos = (
+                    msg.arm_high_spd_feedback_1.pos
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgHighSpdFeed_2:
                 self.__arm_time_stamp.time_stamp_motor_low_spd_2 = time.time_ns()
-                self.__arm_motor_info_high_spd.motor_2.can_id = msg.arm_high_spd_feedback_2.can_id
-                self.__arm_motor_info_high_spd.motor_2.motor_speed = msg.arm_high_spd_feedback_2.motor_speed
-                self.__arm_motor_info_high_spd.motor_2.current = msg.arm_high_spd_feedback_2.current
-                self.__arm_motor_info_high_spd.motor_2.pos = msg.arm_high_spd_feedback_2.pos
-            elif(msg.type_ == ArmMsgType.PiperMsgHighSpdFeed_3):
+                self.__arm_motor_info_high_spd.motor_2.can_id = (
+                    msg.arm_high_spd_feedback_2.can_id
+                )
+                self.__arm_motor_info_high_spd.motor_2.motor_speed = (
+                    msg.arm_high_spd_feedback_2.motor_speed
+                )
+                self.__arm_motor_info_high_spd.motor_2.current = (
+                    msg.arm_high_spd_feedback_2.current
+                )
+                self.__arm_motor_info_high_spd.motor_2.pos = (
+                    msg.arm_high_spd_feedback_2.pos
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgHighSpdFeed_3:
                 self.__arm_time_stamp.time_stamp_motor_low_spd_3 = time.time_ns()
-                self.__arm_motor_info_high_spd.motor_3.can_id = msg.arm_high_spd_feedback_3.can_id
-                self.__arm_motor_info_high_spd.motor_3.motor_speed = msg.arm_high_spd_feedback_3.motor_speed
-                self.__arm_motor_info_high_spd.motor_3.current = msg.arm_high_spd_feedback_3.current
-                self.__arm_motor_info_high_spd.motor_3.pos = msg.arm_high_spd_feedback_3.pos
-            elif(msg.type_ == ArmMsgType.PiperMsgHighSpdFeed_4):
+                self.__arm_motor_info_high_spd.motor_3.can_id = (
+                    msg.arm_high_spd_feedback_3.can_id
+                )
+                self.__arm_motor_info_high_spd.motor_3.motor_speed = (
+                    msg.arm_high_spd_feedback_3.motor_speed
+                )
+                self.__arm_motor_info_high_spd.motor_3.current = (
+                    msg.arm_high_spd_feedback_3.current
+                )
+                self.__arm_motor_info_high_spd.motor_3.pos = (
+                    msg.arm_high_spd_feedback_3.pos
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgHighSpdFeed_4:
                 self.__arm_time_stamp.time_stamp_motor_low_spd_4 = time.time_ns()
-                self.__arm_motor_info_high_spd.motor_4.can_id = msg.arm_high_spd_feedback_4.can_id
-                self.__arm_motor_info_high_spd.motor_4.motor_speed = msg.arm_high_spd_feedback_4.motor_speed
-                self.__arm_motor_info_high_spd.motor_4.current = msg.arm_high_spd_feedback_4.current
-                self.__arm_motor_info_high_spd.motor_4.pos = msg.arm_high_spd_feedback_4.pos
-            elif(msg.type_ == ArmMsgType.PiperMsgHighSpdFeed_5):
+                self.__arm_motor_info_high_spd.motor_4.can_id = (
+                    msg.arm_high_spd_feedback_4.can_id
+                )
+                self.__arm_motor_info_high_spd.motor_4.motor_speed = (
+                    msg.arm_high_spd_feedback_4.motor_speed
+                )
+                self.__arm_motor_info_high_spd.motor_4.current = (
+                    msg.arm_high_spd_feedback_4.current
+                )
+                self.__arm_motor_info_high_spd.motor_4.pos = (
+                    msg.arm_high_spd_feedback_4.pos
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgHighSpdFeed_5:
                 self.__arm_time_stamp.time_stamp_motor_low_spd_5 = time.time_ns()
-                self.__arm_motor_info_high_spd.motor_5.can_id = msg.arm_high_spd_feedback_5.can_id
-                self.__arm_motor_info_high_spd.motor_5.motor_speed = msg.arm_high_spd_feedback_5.motor_speed
-                self.__arm_motor_info_high_spd.motor_5.current = msg.arm_high_spd_feedback_5.current
-                self.__arm_motor_info_high_spd.motor_5.pos = msg.arm_high_spd_feedback_5.pos
-            elif(msg.type_ == ArmMsgType.PiperMsgHighSpdFeed_6):
+                self.__arm_motor_info_high_spd.motor_5.can_id = (
+                    msg.arm_high_spd_feedback_5.can_id
+                )
+                self.__arm_motor_info_high_spd.motor_5.motor_speed = (
+                    msg.arm_high_spd_feedback_5.motor_speed
+                )
+                self.__arm_motor_info_high_spd.motor_5.current = (
+                    msg.arm_high_spd_feedback_5.current
+                )
+                self.__arm_motor_info_high_spd.motor_5.pos = (
+                    msg.arm_high_spd_feedback_5.pos
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgHighSpdFeed_6:
                 self.__arm_time_stamp.time_stamp_motor_low_spd_6 = time.time_ns()
-                self.__arm_motor_info_high_spd.motor_6.can_id = msg.arm_high_spd_feedback_6.can_id
-                self.__arm_motor_info_high_spd.motor_6.motor_speed = msg.arm_high_spd_feedback_6.motor_speed
-                self.__arm_motor_info_high_spd.motor_6.current = msg.arm_high_spd_feedback_6.current
-                self.__arm_motor_info_high_spd.motor_6.pos = msg.arm_high_spd_feedback_6.pos
+                self.__arm_motor_info_high_spd.motor_6.can_id = (
+                    msg.arm_high_spd_feedback_6.can_id
+                )
+                self.__arm_motor_info_high_spd.motor_6.motor_speed = (
+                    msg.arm_high_spd_feedback_6.motor_speed
+                )
+                self.__arm_motor_info_high_spd.motor_6.current = (
+                    msg.arm_high_spd_feedback_6.current
+                )
+                self.__arm_motor_info_high_spd.motor_6.pos = (
+                    msg.arm_high_spd_feedback_6.pos
+                )
             else:
                 pass
             # 更新时间戳，取筛选ID的最新一个
-            self.__arm_motor_info_high_spd.time_stamp = max(self.__arm_time_stamp.time_stamp_motor_low_spd_1, 
-                                                    self.__arm_time_stamp.time_stamp_motor_low_spd_2, 
-                                                    self.__arm_time_stamp.time_stamp_motor_low_spd_3, 
-                                                    self.__arm_time_stamp.time_stamp_motor_low_spd_4, 
-                                                    self.__arm_time_stamp.time_stamp_motor_low_spd_5, 
-                                                    self.__arm_time_stamp.time_stamp_motor_low_spd_6) / 1_000_000_000
+            self.__arm_motor_info_high_spd.time_stamp = (
+                max(
+                    self.__arm_time_stamp.time_stamp_motor_low_spd_1,
+                    self.__arm_time_stamp.time_stamp_motor_low_spd_2,
+                    self.__arm_time_stamp.time_stamp_motor_low_spd_3,
+                    self.__arm_time_stamp.time_stamp_motor_low_spd_4,
+                    self.__arm_time_stamp.time_stamp_motor_low_spd_5,
+                    self.__arm_time_stamp.time_stamp_motor_low_spd_6,
+                )
+                / 1_000_000_000
+            )
             # print(self.__arm_motor_info_high_spd)
             return self.__arm_motor_info_high_spd
-    
-    def UpdateDriverInfoLowSpdFeedback(self, msg:PiperMessage):
+
+    def UpdateDriverInfoLowSpdFeedback(self, msg: PiperMessage):
         """更新驱动器信息反馈, 低速
 
         Args:
             msg (PiperMessage): 输入为机械臂消息汇总
         """
         with self.__arm_motor_info_low_spd_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgLowSpdFeed_1):
+            if msg.type_ == ArmMsgType.PiperMsgLowSpdFeed_1:
                 self.__arm_time_stamp.time_stamp_motor_low_spd_1 = time.time_ns()
-                self.__arm_motor_info_low_spd.motor_1.can_id = msg.arm_low_spd_feedback_1.can_id
-                self.__arm_motor_info_low_spd.motor_1.vol = msg.arm_low_spd_feedback_1.vol
-                self.__arm_motor_info_low_spd.motor_1.foc_temp = msg.arm_low_spd_feedback_1.foc_temp
-                self.__arm_motor_info_low_spd.motor_1.motor_temp = msg.arm_low_spd_feedback_1.motor_temp
-                self.__arm_motor_info_low_spd.motor_1.foc_status_code = msg.arm_low_spd_feedback_1.foc_status_code
-                self.__arm_motor_info_low_spd.motor_1.bus_current = msg.arm_low_spd_feedback_1.bus_current
-            elif(msg.type_ == ArmMsgType.PiperMsgLowSpdFeed_2):
+                self.__arm_motor_info_low_spd.motor_1.can_id = (
+                    msg.arm_low_spd_feedback_1.can_id
+                )
+                self.__arm_motor_info_low_spd.motor_1.vol = (
+                    msg.arm_low_spd_feedback_1.vol
+                )
+                self.__arm_motor_info_low_spd.motor_1.foc_temp = (
+                    msg.arm_low_spd_feedback_1.foc_temp
+                )
+                self.__arm_motor_info_low_spd.motor_1.motor_temp = (
+                    msg.arm_low_spd_feedback_1.motor_temp
+                )
+                self.__arm_motor_info_low_spd.motor_1.foc_status_code = (
+                    msg.arm_low_spd_feedback_1.foc_status_code
+                )
+                self.__arm_motor_info_low_spd.motor_1.bus_current = (
+                    msg.arm_low_spd_feedback_1.bus_current
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgLowSpdFeed_2:
                 self.__arm_time_stamp.time_stamp_motor_low_spd_2 = time.time_ns()
-                self.__arm_motor_info_low_spd.motor_2.can_id = msg.arm_low_spd_feedback_2.can_id
-                self.__arm_motor_info_low_spd.motor_2.vol= msg.arm_low_spd_feedback_2.vol
-                self.__arm_motor_info_low_spd.motor_2.foc_temp = msg.arm_low_spd_feedback_2.foc_temp
-                self.__arm_motor_info_low_spd.motor_2.motor_temp = msg.arm_low_spd_feedback_2.motor_temp
-                self.__arm_motor_info_low_spd.motor_2.foc_status_code = msg.arm_low_spd_feedback_2.foc_status_code
-                self.__arm_motor_info_low_spd.motor_2.bus_current = msg.arm_low_spd_feedback_2.bus_current
-            elif(msg.type_ == ArmMsgType.PiperMsgLowSpdFeed_3):
+                self.__arm_motor_info_low_spd.motor_2.can_id = (
+                    msg.arm_low_spd_feedback_2.can_id
+                )
+                self.__arm_motor_info_low_spd.motor_2.vol = (
+                    msg.arm_low_spd_feedback_2.vol
+                )
+                self.__arm_motor_info_low_spd.motor_2.foc_temp = (
+                    msg.arm_low_spd_feedback_2.foc_temp
+                )
+                self.__arm_motor_info_low_spd.motor_2.motor_temp = (
+                    msg.arm_low_spd_feedback_2.motor_temp
+                )
+                self.__arm_motor_info_low_spd.motor_2.foc_status_code = (
+                    msg.arm_low_spd_feedback_2.foc_status_code
+                )
+                self.__arm_motor_info_low_spd.motor_2.bus_current = (
+                    msg.arm_low_spd_feedback_2.bus_current
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgLowSpdFeed_3:
                 self.__arm_time_stamp.time_stamp_motor_low_spd_3 = time.time_ns()
-                self.__arm_motor_info_low_spd.motor_3.can_id = msg.arm_low_spd_feedback_3.can_id
-                self.__arm_motor_info_low_spd.motor_3.vol = msg.arm_low_spd_feedback_3.vol
-                self.__arm_motor_info_low_spd.motor_3.foc_temp = msg.arm_low_spd_feedback_3.foc_temp
-                self.__arm_motor_info_low_spd.motor_3.motor_temp = msg.arm_low_spd_feedback_3.motor_temp
-                self.__arm_motor_info_low_spd.motor_3.foc_status_code = msg.arm_low_spd_feedback_3.foc_status_code
-                self.__arm_motor_info_low_spd.motor_3.bus_current = msg.arm_low_spd_feedback_3.bus_current
-            elif(msg.type_ == ArmMsgType.PiperMsgLowSpdFeed_4):
+                self.__arm_motor_info_low_spd.motor_3.can_id = (
+                    msg.arm_low_spd_feedback_3.can_id
+                )
+                self.__arm_motor_info_low_spd.motor_3.vol = (
+                    msg.arm_low_spd_feedback_3.vol
+                )
+                self.__arm_motor_info_low_spd.motor_3.foc_temp = (
+                    msg.arm_low_spd_feedback_3.foc_temp
+                )
+                self.__arm_motor_info_low_spd.motor_3.motor_temp = (
+                    msg.arm_low_spd_feedback_3.motor_temp
+                )
+                self.__arm_motor_info_low_spd.motor_3.foc_status_code = (
+                    msg.arm_low_spd_feedback_3.foc_status_code
+                )
+                self.__arm_motor_info_low_spd.motor_3.bus_current = (
+                    msg.arm_low_spd_feedback_3.bus_current
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgLowSpdFeed_4:
                 self.__arm_time_stamp.time_stamp_motor_low_spd_4 = time.time_ns()
-                self.__arm_motor_info_low_spd.motor_4.can_id = msg.arm_low_spd_feedback_4.can_id
-                self.__arm_motor_info_low_spd.motor_4.vol = msg.arm_low_spd_feedback_4.vol
-                self.__arm_motor_info_low_spd.motor_4.foc_temp = msg.arm_low_spd_feedback_4.foc_temp
-                self.__arm_motor_info_low_spd.motor_4.motor_temp = msg.arm_low_spd_feedback_4.motor_temp
-                self.__arm_motor_info_low_spd.motor_4.foc_status_code = msg.arm_low_spd_feedback_4.foc_status_code
-                self.__arm_motor_info_low_spd.motor_4.bus_current = msg.arm_low_spd_feedback_4.bus_current
-            elif(msg.type_ == ArmMsgType.PiperMsgLowSpdFeed_5):
+                self.__arm_motor_info_low_spd.motor_4.can_id = (
+                    msg.arm_low_spd_feedback_4.can_id
+                )
+                self.__arm_motor_info_low_spd.motor_4.vol = (
+                    msg.arm_low_spd_feedback_4.vol
+                )
+                self.__arm_motor_info_low_spd.motor_4.foc_temp = (
+                    msg.arm_low_spd_feedback_4.foc_temp
+                )
+                self.__arm_motor_info_low_spd.motor_4.motor_temp = (
+                    msg.arm_low_spd_feedback_4.motor_temp
+                )
+                self.__arm_motor_info_low_spd.motor_4.foc_status_code = (
+                    msg.arm_low_spd_feedback_4.foc_status_code
+                )
+                self.__arm_motor_info_low_spd.motor_4.bus_current = (
+                    msg.arm_low_spd_feedback_4.bus_current
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgLowSpdFeed_5:
                 self.__arm_time_stamp.time_stamp_motor_low_spd_5 = time.time_ns()
-                self.__arm_motor_info_low_spd.motor_5.can_id = msg.arm_low_spd_feedback_5.can_id
-                self.__arm_motor_info_low_spd.motor_5.vol = msg.arm_low_spd_feedback_5.vol
-                self.__arm_motor_info_low_spd.motor_5.foc_temp = msg.arm_low_spd_feedback_5.foc_temp
-                self.__arm_motor_info_low_spd.motor_5.motor_temp = msg.arm_low_spd_feedback_5.motor_temp
-                self.__arm_motor_info_low_spd.motor_5.foc_status_code = msg.arm_low_spd_feedback_5.foc_status_code
-                self.__arm_motor_info_low_spd.motor_5.bus_current = msg.arm_low_spd_feedback_5.bus_current
-            elif(msg.type_ == ArmMsgType.PiperMsgLowSpdFeed_6):
+                self.__arm_motor_info_low_spd.motor_5.can_id = (
+                    msg.arm_low_spd_feedback_5.can_id
+                )
+                self.__arm_motor_info_low_spd.motor_5.vol = (
+                    msg.arm_low_spd_feedback_5.vol
+                )
+                self.__arm_motor_info_low_spd.motor_5.foc_temp = (
+                    msg.arm_low_spd_feedback_5.foc_temp
+                )
+                self.__arm_motor_info_low_spd.motor_5.motor_temp = (
+                    msg.arm_low_spd_feedback_5.motor_temp
+                )
+                self.__arm_motor_info_low_spd.motor_5.foc_status_code = (
+                    msg.arm_low_spd_feedback_5.foc_status_code
+                )
+                self.__arm_motor_info_low_spd.motor_5.bus_current = (
+                    msg.arm_low_spd_feedback_5.bus_current
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgLowSpdFeed_6:
                 self.__arm_time_stamp.time_stamp_motor_low_spd_6 = time.time_ns()
-                self.__arm_motor_info_low_spd.motor_6.can_id = msg.arm_low_spd_feedback_6.can_id
-                self.__arm_motor_info_low_spd.motor_6.vol = msg.arm_low_spd_feedback_6.vol
-                self.__arm_motor_info_low_spd.motor_6.foc_temp = msg.arm_low_spd_feedback_6.foc_temp
-                self.__arm_motor_info_low_spd.motor_6.motor_temp = msg.arm_low_spd_feedback_6.motor_temp
-                self.__arm_motor_info_low_spd.motor_6.foc_status_code = msg.arm_low_spd_feedback_6.foc_status_code
-                self.__arm_motor_info_low_spd.motor_6.bus_current = msg.arm_low_spd_feedback_6.bus_current
+                self.__arm_motor_info_low_spd.motor_6.can_id = (
+                    msg.arm_low_spd_feedback_6.can_id
+                )
+                self.__arm_motor_info_low_spd.motor_6.vol = (
+                    msg.arm_low_spd_feedback_6.vol
+                )
+                self.__arm_motor_info_low_spd.motor_6.foc_temp = (
+                    msg.arm_low_spd_feedback_6.foc_temp
+                )
+                self.__arm_motor_info_low_spd.motor_6.motor_temp = (
+                    msg.arm_low_spd_feedback_6.motor_temp
+                )
+                self.__arm_motor_info_low_spd.motor_6.foc_status_code = (
+                    msg.arm_low_spd_feedback_6.foc_status_code
+                )
+                self.__arm_motor_info_low_spd.motor_6.bus_current = (
+                    msg.arm_low_spd_feedback_6.bus_current
+                )
             else:
                 pass
             # 更新时间戳，取筛选ID的最新一个
-            self.__arm_motor_info_low_spd.time_stamp = max(self.__arm_time_stamp.time_stamp_motor_low_spd_1, 
-                                                            self.__arm_time_stamp.time_stamp_motor_low_spd_2, 
-                                                            self.__arm_time_stamp.time_stamp_motor_low_spd_3, 
-                                                            self.__arm_time_stamp.time_stamp_motor_low_spd_4, 
-                                                            self.__arm_time_stamp.time_stamp_motor_low_spd_5, 
-                                                            self.__arm_time_stamp.time_stamp_motor_low_spd_6) / 1_000_000_000
+            self.__arm_motor_info_low_spd.time_stamp = (
+                max(
+                    self.__arm_time_stamp.time_stamp_motor_low_spd_1,
+                    self.__arm_time_stamp.time_stamp_motor_low_spd_2,
+                    self.__arm_time_stamp.time_stamp_motor_low_spd_3,
+                    self.__arm_time_stamp.time_stamp_motor_low_spd_4,
+                    self.__arm_time_stamp.time_stamp_motor_low_spd_5,
+                    self.__arm_time_stamp.time_stamp_motor_low_spd_6,
+                )
+                / 1_000_000_000
+            )
             # print(self.__arm_motor_info_low_spd)
             return self.__arm_motor_info_low_spd
-    
-    def UpdateCurrentMotorAngleLimitMaxVel(self, msg:PiperMessage):
-        '''
+
+    def UpdateCurrentMotorAngleLimitMaxVel(self, msg: PiperMessage):
+        """
         更新
         反馈当前电机限制角度/最大速度
         为主动发送指令后反馈消息
         对应查询电机角度/最大速度/最大加速度限制指令 0x472 Byte 1 = 0x01
-        
+
         0x473
-        '''
+        """
         with self.__feedback_current_motor_angle_limit_max_vel_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgFeedbackCurrentMotorAngleLimitMaxSpd):
-                self.__feedback_current_motor_angle_limit_max_vel.time_stamp = time.time_ns()/ 1_000_000_000
-                self.__feedback_current_motor_angle_limit_max_vel.current_motor_angle_limit_max_vel.motor_num = \
+            if msg.type_ == ArmMsgType.PiperMsgFeedbackCurrentMotorAngleLimitMaxSpd:
+                self.__feedback_current_motor_angle_limit_max_vel.time_stamp = (
+                    time.time_ns() / 1_000_000_000
+                )
+                self.__feedback_current_motor_angle_limit_max_vel.current_motor_angle_limit_max_vel.motor_num = (
                     msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num
-                self.__feedback_current_motor_angle_limit_max_vel.current_motor_angle_limit_max_vel.max_angle_limit = \
+                )
+                self.__feedback_current_motor_angle_limit_max_vel.current_motor_angle_limit_max_vel.max_angle_limit = (
                     msg.arm_feedback_current_motor_angle_limit_max_spd.max_angle_limit
-                self.__feedback_current_motor_angle_limit_max_vel.current_motor_angle_limit_max_vel.min_angle_limit = \
+                )
+                self.__feedback_current_motor_angle_limit_max_vel.current_motor_angle_limit_max_vel.min_angle_limit = (
                     msg.arm_feedback_current_motor_angle_limit_max_spd.min_angle_limit
-                self.__feedback_current_motor_angle_limit_max_vel.current_motor_angle_limit_max_vel.max_jonit_spd = \
+                )
+                self.__feedback_current_motor_angle_limit_max_vel.current_motor_angle_limit_max_vel.max_jonit_spd = (
                     msg.arm_feedback_current_motor_angle_limit_max_spd.max_jonit_spd
+                )
             # print(self.__feedback_current_motor_angle_limit_max_vel)
             return self.__feedback_current_motor_angle_limit_max_vel
-    
-    def UpdateCurrentMotorMaxAccLimit(self, msg:PiperMessage):
-        '''
+
+    def UpdateCurrentMotorMaxAccLimit(self, msg: PiperMessage):
+        """
         反馈当前电机最大加速度限制
         为主动发送指令后反馈消息
         对应查询电机角度/最大速度/最大加速度限制指令 0x472 Byte 1 = 0x02
 
         0x47C
-        '''
+        """
         with self.__feedback_current_motor_max_acc_limit_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgFeedbackCurrentMotorMaxAccLimit):
-                self.__feedback_current_motor_max_acc_limit.time_stamp = time.time_ns()/ 1_000_000_000
-                self.__feedback_current_motor_max_acc_limit.current_motor_max_acc_limit.joint_motor_num = \
+            if msg.type_ == ArmMsgType.PiperMsgFeedbackCurrentMotorMaxAccLimit:
+                self.__feedback_current_motor_max_acc_limit.time_stamp = (
+                    time.time_ns() / 1_000_000_000
+                )
+                self.__feedback_current_motor_max_acc_limit.current_motor_max_acc_limit.joint_motor_num = (
                     msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num
-                self.__feedback_current_motor_max_acc_limit.current_motor_max_acc_limit.max_joint_acc = \
+                )
+                self.__feedback_current_motor_max_acc_limit.current_motor_max_acc_limit.max_joint_acc = (
                     msg.arm_feedback_current_motor_max_acc_limit.max_joint_acc
+                )
             # print(self.__feedback_current_motor_max_acc_limit)
             return self.__feedback_current_motor_max_acc_limit
-    
-    def UpdateAllCurrentMotorAngleLimitMaxVel(self, msg:PiperMessage):
-        '''
+
+    def UpdateAllCurrentMotorAngleLimitMaxVel(self, msg: PiperMessage):
+        """
         更新
         反馈全部电机限制角度/最大速度
         为主动发送指令后反馈消息
         对应查询电机角度/最大速度/最大加速度限制指令 0x472 Byte 1 = 0x01
-        
+
         0x473
-        '''
+        """
         with self.__arm_all_motor_angle_limit_max_spd_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgFeedbackCurrentMotorAngleLimitMaxSpd):
-                if(msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num == 1):
-                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_1 = time.time_ns()
-                    self.__arm_all_motor_angle_limit_max_spd.all_motor_angle_limit_max_spd.motor[1]=msg.arm_feedback_current_motor_angle_limit_max_spd
-                elif(msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num == 2):
-                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_2 = time.time_ns()
-                    self.__arm_all_motor_angle_limit_max_spd.all_motor_angle_limit_max_spd.motor[2]=msg.arm_feedback_current_motor_angle_limit_max_spd
-                elif(msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num == 3):
-                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_3 = time.time_ns()
-                    self.__arm_all_motor_angle_limit_max_spd.all_motor_angle_limit_max_spd.motor[3]=msg.arm_feedback_current_motor_angle_limit_max_spd
-                elif(msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num == 4):
-                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_4 = time.time_ns()
-                    self.__arm_all_motor_angle_limit_max_spd.all_motor_angle_limit_max_spd.motor[4]=msg.arm_feedback_current_motor_angle_limit_max_spd
-                elif(msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num == 5):
-                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_5 = time.time_ns()
-                    self.__arm_all_motor_angle_limit_max_spd.all_motor_angle_limit_max_spd.motor[5]=msg.arm_feedback_current_motor_angle_limit_max_spd
-                elif(msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num == 6):
-                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_6 = time.time_ns()
-                    self.__arm_all_motor_angle_limit_max_spd.all_motor_angle_limit_max_spd.motor[6]=msg.arm_feedback_current_motor_angle_limit_max_spd
+            if msg.type_ == ArmMsgType.PiperMsgFeedbackCurrentMotorAngleLimitMaxSpd:
+                if msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num == 1:
+                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_1 = (
+                        time.time_ns()
+                    )
+                    self.__arm_all_motor_angle_limit_max_spd.all_motor_angle_limit_max_spd.motor[
+                        1
+                    ] = msg.arm_feedback_current_motor_angle_limit_max_spd
+                elif msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num == 2:
+                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_2 = (
+                        time.time_ns()
+                    )
+                    self.__arm_all_motor_angle_limit_max_spd.all_motor_angle_limit_max_spd.motor[
+                        2
+                    ] = msg.arm_feedback_current_motor_angle_limit_max_spd
+                elif msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num == 3:
+                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_3 = (
+                        time.time_ns()
+                    )
+                    self.__arm_all_motor_angle_limit_max_spd.all_motor_angle_limit_max_spd.motor[
+                        3
+                    ] = msg.arm_feedback_current_motor_angle_limit_max_spd
+                elif msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num == 4:
+                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_4 = (
+                        time.time_ns()
+                    )
+                    self.__arm_all_motor_angle_limit_max_spd.all_motor_angle_limit_max_spd.motor[
+                        4
+                    ] = msg.arm_feedback_current_motor_angle_limit_max_spd
+                elif msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num == 5:
+                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_5 = (
+                        time.time_ns()
+                    )
+                    self.__arm_all_motor_angle_limit_max_spd.all_motor_angle_limit_max_spd.motor[
+                        5
+                    ] = msg.arm_feedback_current_motor_angle_limit_max_spd
+                elif msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num == 6:
+                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_6 = (
+                        time.time_ns()
+                    )
+                    self.__arm_all_motor_angle_limit_max_spd.all_motor_angle_limit_max_spd.motor[
+                        6
+                    ] = msg.arm_feedback_current_motor_angle_limit_max_spd
                 # 更新时间戳，取筛选ID的最新一个
-                self.__arm_all_motor_angle_limit_max_spd.time_stamp = max(self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_1, 
-                                                                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_2, 
-                                                                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_3, 
-                                                                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_4, 
-                                                                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_5, 
-                                                                    self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_6) / 1_000_000_000
+                self.__arm_all_motor_angle_limit_max_spd.time_stamp = (
+                    max(
+                        self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_1,
+                        self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_2,
+                        self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_3,
+                        self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_4,
+                        self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_5,
+                        self.__arm_time_stamp.time_stamp_motor_angle_limit_max_spd_6,
+                    )
+                    / 1_000_000_000
+                )
             # print(self.__arm_all_motor_angle_limit_max_spd)
             return self.__arm_all_motor_angle_limit_max_spd
-    
-    def UpdateAllCurrentMotorMaxAccLimit(self, msg:PiperMessage):
-        '''
+
+    def UpdateAllCurrentMotorMaxAccLimit(self, msg: PiperMessage):
+        """
         反馈全部电机最大加速度限制
         为主动发送指令后反馈消息
         对应查询电机角度/最大速度/最大加速度限制指令 0x472 Byte 1 = 0x02
 
         0x47C
-        '''
+        """
         with self.__arm_all_motor_max_acc_limit_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgFeedbackCurrentMotorMaxAccLimit):
-                if(msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num == 1):
-                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_1 = time.time_ns()
-                    self.__arm_all_motor_max_acc_limit.all_motor_max_acc_limit.motor[1]=msg.arm_feedback_current_motor_max_acc_limit
-                elif(msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num == 2):
-                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_2 = time.time_ns()
-                    self.__arm_all_motor_max_acc_limit.all_motor_max_acc_limit.motor[2]=msg.arm_feedback_current_motor_max_acc_limit
-                elif(msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num == 3):
-                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_3 = time.time_ns()
-                    self.__arm_all_motor_max_acc_limit.all_motor_max_acc_limit.motor[3]=msg.arm_feedback_current_motor_max_acc_limit
-                elif(msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num == 4):
-                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_4 = time.time_ns()
-                    self.__arm_all_motor_max_acc_limit.all_motor_max_acc_limit.motor[4]=msg.arm_feedback_current_motor_max_acc_limit
-                elif(msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num == 5):
-                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_5 = time.time_ns()
-                    self.__arm_all_motor_max_acc_limit.all_motor_max_acc_limit.motor[5]=msg.arm_feedback_current_motor_max_acc_limit
-                elif(msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num == 6):
-                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_6 = time.time_ns()
-                    self.__arm_all_motor_max_acc_limit.all_motor_max_acc_limit.motor[6]=msg.arm_feedback_current_motor_max_acc_limit
+            if msg.type_ == ArmMsgType.PiperMsgFeedbackCurrentMotorMaxAccLimit:
+                if msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num == 1:
+                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_1 = (
+                        time.time_ns()
+                    )
+                    self.__arm_all_motor_max_acc_limit.all_motor_max_acc_limit.motor[
+                        1
+                    ] = msg.arm_feedback_current_motor_max_acc_limit
+                elif msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num == 2:
+                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_2 = (
+                        time.time_ns()
+                    )
+                    self.__arm_all_motor_max_acc_limit.all_motor_max_acc_limit.motor[
+                        2
+                    ] = msg.arm_feedback_current_motor_max_acc_limit
+                elif msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num == 3:
+                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_3 = (
+                        time.time_ns()
+                    )
+                    self.__arm_all_motor_max_acc_limit.all_motor_max_acc_limit.motor[
+                        3
+                    ] = msg.arm_feedback_current_motor_max_acc_limit
+                elif msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num == 4:
+                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_4 = (
+                        time.time_ns()
+                    )
+                    self.__arm_all_motor_max_acc_limit.all_motor_max_acc_limit.motor[
+                        4
+                    ] = msg.arm_feedback_current_motor_max_acc_limit
+                elif msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num == 5:
+                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_5 = (
+                        time.time_ns()
+                    )
+                    self.__arm_all_motor_max_acc_limit.all_motor_max_acc_limit.motor[
+                        5
+                    ] = msg.arm_feedback_current_motor_max_acc_limit
+                elif msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num == 6:
+                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_6 = (
+                        time.time_ns()
+                    )
+                    self.__arm_all_motor_max_acc_limit.all_motor_max_acc_limit.motor[
+                        6
+                    ] = msg.arm_feedback_current_motor_max_acc_limit
                 # 更新时间戳，取筛选ID的最新一个
-                self.__arm_all_motor_max_acc_limit.time_stamp = max(self.__arm_time_stamp.time_stamp_motor_max_acc_limit_1, 
-                                                                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_2, 
-                                                                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_3, 
-                                                                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_4, 
-                                                                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_5, 
-                                                                    self.__arm_time_stamp.time_stamp_motor_max_acc_limit_6) / 1_000_000_000
+                self.__arm_all_motor_max_acc_limit.time_stamp = (
+                    max(
+                        self.__arm_time_stamp.time_stamp_motor_max_acc_limit_1,
+                        self.__arm_time_stamp.time_stamp_motor_max_acc_limit_2,
+                        self.__arm_time_stamp.time_stamp_motor_max_acc_limit_3,
+                        self.__arm_time_stamp.time_stamp_motor_max_acc_limit_4,
+                        self.__arm_time_stamp.time_stamp_motor_max_acc_limit_5,
+                        self.__arm_time_stamp.time_stamp_motor_max_acc_limit_6,
+                    )
+                    / 1_000_000_000
+                )
             # print(self.__arm_all_motor_max_acc_limit)
             return self.__arm_all_motor_max_acc_limit
-    
-    def UpdateCurrentEndVelAndAccParam(self, msg:PiperMessage):
-        '''
+
+    def UpdateCurrentEndVelAndAccParam(self, msg: PiperMessage):
+        """
         反馈当前末端速度/加速度参数
         为主动发送指令后反馈消息
 
         对应机械臂参数查询与设置指令 0x477 Byte 0 = 0x01
 
         0x478
-        '''
+        """
         with self.__feedback_current_end_vel_acc_param_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgFeedbackCurrentEndVelAccParam):
-                self.__feedback_current_end_vel_acc_param.time_stamp = time.time_ns()/ 1_000_000_000
-                self.__feedback_current_end_vel_acc_param.current_end_vel_acc_param.end_max_linear_vel = \
+            if msg.type_ == ArmMsgType.PiperMsgFeedbackCurrentEndVelAccParam:
+                self.__feedback_current_end_vel_acc_param.time_stamp = (
+                    time.time_ns() / 1_000_000_000
+                )
+                self.__feedback_current_end_vel_acc_param.current_end_vel_acc_param.end_max_linear_vel = (
                     msg.arm_feedback_current_end_vel_acc_param.end_max_linear_vel
-                self.__feedback_current_end_vel_acc_param.current_end_vel_acc_param.end_max_angular_vel = \
+                )
+                self.__feedback_current_end_vel_acc_param.current_end_vel_acc_param.end_max_angular_vel = (
                     msg.arm_feedback_current_end_vel_acc_param.end_max_angular_vel
-                self.__feedback_current_end_vel_acc_param.current_end_vel_acc_param.end_max_linear_acc = \
+                )
+                self.__feedback_current_end_vel_acc_param.current_end_vel_acc_param.end_max_linear_acc = (
                     msg.arm_feedback_current_end_vel_acc_param.end_max_linear_acc
-                self.__feedback_current_end_vel_acc_param.current_end_vel_acc_param.end_max_angular_acc = \
+                )
+                self.__feedback_current_end_vel_acc_param.current_end_vel_acc_param.end_max_angular_acc = (
                     msg.arm_feedback_current_end_vel_acc_param.end_max_angular_acc
+                )
             # print(self.__feedback_current_end_vel_acc_param)
             return self.__feedback_current_end_vel_acc_param
-    
-    def UpdateCrashProtectionLevelFeedback(self, msg:PiperMessage):
-        '''
+
+    def UpdateCrashProtectionLevelFeedback(self, msg: PiperMessage):
+        """
         碰撞防护等级设置反馈指令
         为主动发送指令后反馈消息
         对应机械臂参数查询与设置指令 0x477 Byte 0 = 0x02
 
         0x47B
-        '''
+        """
         with self.__feedback_crash_protection_level_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgCrashProtectionRatingFeedback):
-                self.__feedback_crash_protection_level.time_stamp = time.time_ns()/ 1_000_000_000
-                self.__feedback_crash_protection_level.crash_protection_level_feedback.jonit_1_protection_level=\
+            if msg.type_ == ArmMsgType.PiperMsgCrashProtectionRatingFeedback:
+                self.__feedback_crash_protection_level.time_stamp = (
+                    time.time_ns() / 1_000_000_000
+                )
+                self.__feedback_crash_protection_level.crash_protection_level_feedback.jonit_1_protection_level = (
                     msg.arm_crash_protection_rating_feedback.jonit_1_protection_level
-                self.__feedback_crash_protection_level.crash_protection_level_feedback.jonit_2_protection_level=\
+                )
+                self.__feedback_crash_protection_level.crash_protection_level_feedback.jonit_2_protection_level = (
                     msg.arm_crash_protection_rating_feedback.jonit_2_protection_level
-                self.__feedback_crash_protection_level.crash_protection_level_feedback.jonit_3_protection_level=\
+                )
+                self.__feedback_crash_protection_level.crash_protection_level_feedback.jonit_3_protection_level = (
                     msg.arm_crash_protection_rating_feedback.jonit_3_protection_level
-                self.__feedback_crash_protection_level.crash_protection_level_feedback.jonit_4_protection_level=\
+                )
+                self.__feedback_crash_protection_level.crash_protection_level_feedback.jonit_4_protection_level = (
                     msg.arm_crash_protection_rating_feedback.jonit_4_protection_level
-                self.__feedback_crash_protection_level.crash_protection_level_feedback.jonit_5_protection_level=\
+                )
+                self.__feedback_crash_protection_level.crash_protection_level_feedback.jonit_5_protection_level = (
                     msg.arm_crash_protection_rating_feedback.jonit_5_protection_level
-                self.__feedback_crash_protection_level.crash_protection_level_feedback.jonit_6_protection_level=\
+                )
+                self.__feedback_crash_protection_level.crash_protection_level_feedback.jonit_6_protection_level = (
                     msg.arm_crash_protection_rating_feedback.jonit_6_protection_level
+                )
             # print(self.__feedback_crash_protection_level)
             return self.__feedback_crash_protection_level
-    
-    def UpdateArmJointCtrl(self, msg:PiperMessage):
+
+    def UpdateArmJointCtrl(self, msg: PiperMessage):
         """更新关节和夹爪状态,为主臂发送的消息
 
         Args:
             msg (PiperMessage): 输入为机械臂消息汇总
         """
         with self.__arm_joint_ctrl_msgs_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgJointCtrl_12):
+            if msg.type_ == ArmMsgType.PiperMsgJointCtrl_12:
                 self.__arm_time_stamp.time_stamp_joint_ctrl_12 = time.time_ns()
                 # print(msg.arm_joint_ctrl)
-                self.__arm_joint_ctrl_msgs.joint_ctrl.joint_1 = msg.arm_joint_ctrl.joint_1
-                self.__arm_joint_ctrl_msgs.joint_ctrl.joint_2 = msg.arm_joint_ctrl.joint_2
-            elif(msg.type_ == ArmMsgType.PiperMsgJointCtrl_34):
+                self.__arm_joint_ctrl_msgs.joint_ctrl.joint_1 = (
+                    msg.arm_joint_ctrl.joint_1
+                )
+                self.__arm_joint_ctrl_msgs.joint_ctrl.joint_2 = (
+                    msg.arm_joint_ctrl.joint_2
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgJointCtrl_34:
                 self.__arm_time_stamp.time_stamp_joint_ctrl_34 = time.time_ns()
-                self.__arm_joint_ctrl_msgs.joint_ctrl.joint_3 = msg.arm_joint_ctrl.joint_3
-                self.__arm_joint_ctrl_msgs.joint_ctrl.joint_4 = msg.arm_joint_ctrl.joint_4
-            elif(msg.type_ == ArmMsgType.PiperMsgJointCtrl_56):
+                self.__arm_joint_ctrl_msgs.joint_ctrl.joint_3 = (
+                    msg.arm_joint_ctrl.joint_3
+                )
+                self.__arm_joint_ctrl_msgs.joint_ctrl.joint_4 = (
+                    msg.arm_joint_ctrl.joint_4
+                )
+            elif msg.type_ == ArmMsgType.PiperMsgJointCtrl_56:
                 self.__arm_time_stamp.time_stamp_joint_ctrl_56 = time.time_ns()
-                self.__arm_joint_ctrl_msgs.joint_ctrl.joint_5 = msg.arm_joint_ctrl.joint_5
-                self.__arm_joint_ctrl_msgs.joint_ctrl.joint_6 = msg.arm_joint_ctrl.joint_6
+                self.__arm_joint_ctrl_msgs.joint_ctrl.joint_5 = (
+                    msg.arm_joint_ctrl.joint_5
+                )
+                self.__arm_joint_ctrl_msgs.joint_ctrl.joint_6 = (
+                    msg.arm_joint_ctrl.joint_6
+                )
             else:
                 pass
             # 更新时间戳，取筛选ID的最新一个
-            self.__arm_joint_ctrl_msgs.time_stamp = max(self.__arm_time_stamp.time_stamp_joint_ctrl_12, 
-                                                        self.__arm_time_stamp.time_stamp_joint_ctrl_34, 
-                                                        self.__arm_time_stamp.time_stamp_joint_ctrl_56)/ 1_000_000_000
+            self.__arm_joint_ctrl_msgs.time_stamp = (
+                max(
+                    self.__arm_time_stamp.time_stamp_joint_ctrl_12,
+                    self.__arm_time_stamp.time_stamp_joint_ctrl_34,
+                    self.__arm_time_stamp.time_stamp_joint_ctrl_56,
+                )
+                / 1_000_000_000
+            )
             # print(self.__arm_joint_ctrl_msgs)
             return self.__arm_joint_ctrl_msgs
-    
-    def UpdateArmGripperCtrl(self, msg:PiperMessage):
+
+    def UpdateArmGripperCtrl(self, msg: PiperMessage):
         """更新夹爪状态,为主臂发送的消息
 
         Args:
             msg (PiperMessage): 输入为机械臂消息汇总
         """
         with self.__arm_gripper_ctrl_msgs_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgGripperCtrl):
+            if msg.type_ == ArmMsgType.PiperMsgGripperCtrl:
                 self.__arm_gripper_ctrl_msgs.time_stamp = time.time_ns()
-                self.__arm_gripper_ctrl_msgs.gripper_ctrl.grippers_angle = msg.arm_gripper_ctrl.grippers_angle
-                self.__arm_gripper_ctrl_msgs.gripper_ctrl.grippers_effort = msg.arm_gripper_ctrl.grippers_effort
-                self.__arm_gripper_ctrl_msgs.gripper_ctrl.status_code = msg.arm_gripper_ctrl.status_code
-                self.__arm_gripper_ctrl_msgs.gripper_ctrl.set_zero = msg.arm_gripper_ctrl.set_zero
+                self.__arm_gripper_ctrl_msgs.gripper_ctrl.grippers_angle = (
+                    msg.arm_gripper_ctrl.grippers_angle
+                )
+                self.__arm_gripper_ctrl_msgs.gripper_ctrl.grippers_effort = (
+                    msg.arm_gripper_ctrl.grippers_effort
+                )
+                self.__arm_gripper_ctrl_msgs.gripper_ctrl.status_code = (
+                    msg.arm_gripper_ctrl.status_code
+                )
+                self.__arm_gripper_ctrl_msgs.gripper_ctrl.set_zero = (
+                    msg.arm_gripper_ctrl.set_zero
+                )
             else:
                 pass
             # print(self.__arm_gripper_ctrl_msgs)
             return self.__arm_gripper_ctrl_msgs
-    
-    def UpdateArmCtrlCode151(self, msg:PiperMessage):
-        '''
+
+    def UpdateArmCtrlCode151(self, msg: PiperMessage):
+        """
         更新主臂发送的151控制指令
 
         0x151
-        '''
+        """
         with self.__arm_ctrl_code_151_mtx:
-            if(msg.type_ == ArmMsgType.PiperMsgMotionCtrl_2):
-                self.__arm_ctrl_code_151.time_stamp = time.time_ns()/ 1_000_000_000
-                self.__arm_ctrl_code_151.ctrl_151.ctrl_mode = \
+            if msg.type_ == ArmMsgType.PiperMsgMotionCtrl_2:
+                self.__arm_ctrl_code_151.time_stamp = time.time_ns() / 1_000_000_000
+                self.__arm_ctrl_code_151.ctrl_151.ctrl_mode = (
                     msg.arm_motion_ctrl_2.ctrl_mode
-                self.__arm_ctrl_code_151.ctrl_151.move_mode = \
+                )
+                self.__arm_ctrl_code_151.ctrl_151.move_mode = (
                     msg.arm_motion_ctrl_2.move_mode
-                self.__arm_ctrl_code_151.ctrl_151.move_spd_rate_ctrl = \
+                )
+                self.__arm_ctrl_code_151.ctrl_151.move_spd_rate_ctrl = (
                     msg.arm_motion_ctrl_2.move_spd_rate_ctrl
-                self.__arm_ctrl_code_151.ctrl_151.mit_mode = \
+                )
+                self.__arm_ctrl_code_151.ctrl_151.mit_mode = (
                     msg.arm_motion_ctrl_2.mit_mode
-                self.__arm_ctrl_code_151.ctrl_151.residence_time = \
+                )
+                self.__arm_ctrl_code_151.ctrl_151.residence_time = (
                     msg.arm_motion_ctrl_2.residence_time
+                )
             # print(self.__arm_ctrl_code_151)
             return self.__arm_ctrl_code_151
+
     # 控制发送函数------------------------------------------------------------------------------------------------------
     def MotionCtrl_1(self, emergency_stop, track_ctrl, grag_teach_ctrl):
-        '''
-        机械臂运动控制指令1 
+        """
+        机械臂运动控制指令1
 
         Byte 0 快速急停 uint8 0x00 无效
                             0x01 快速急停 0x02 恢复
         Byte 1 轨迹指令 uint8 0x00 关闭
-                            0x01 暂停当前规划 
+                            0x01 暂停当前规划
                             0x02 继续当前轨迹
-                            0x03 清除当前轨迹 
-                            0x04 清除所有轨迹 
-                            0x05 获取当前规划轨迹 
-                            0x06 终止执行 
-                            0x07 轨迹传输 
+                            0x03 清除当前轨迹
+                            0x04 清除所有轨迹
+                            0x05 获取当前规划轨迹
+                            0x06 终止执行
+                            0x07 轨迹传输
                             0x08 轨迹传输结束
         Byte 2 拖动示教指令 uint8 0x00 关闭
-                                0x01 开始示教记录（进入拖动示教模式） 
-                                0x02 结束示教记录（退出拖动示教模式） 
-                                0x03 执行示教轨迹（拖动示教轨迹复现） 
-                                0x04 暂停执行 
-                                0x05 继续执行（轨迹复现继续） 
-                                0x06 终止执行 
+                                0x01 开始示教记录（进入拖动示教模式）
+                                0x02 结束示教记录（退出拖动示教模式）
+                                0x03 执行示教轨迹（拖动示教轨迹复现）
+                                0x04 暂停执行
+                                0x05 继续执行（轨迹复现继续）
+                                0x06 终止执行
                                 0x07 运动到轨迹起点
         Byte 3 轨迹索引 uint8 标记刚才传输的轨迹点为第N个轨迹点
                                 N=0~255 主控收到后会应答0x476 byte0 = 0x50 ;
                                 byte 2=N(详见0x476 )未收到应答需要重传
         Byte 4 NameIndex_H uint16 当前轨迹包名称索引,由NameIndex和crc组成(应答0x477 byte0=03) Byte 5 crc16 uint16
-        '''
-        tx_can=Message()
+        """
+        tx_can = Message()
         motion_ctrl_1 = ArmMsgMotionCtrl_1(emergency_stop, track_ctrl, grag_teach_ctrl)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgMotionCtrl_1, arm_motion_ctrl_1=motion_ctrl_1)
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgMotionCtrl_1, arm_motion_ctrl_1=motion_ctrl_1
+        )
         self.parser.EncodeMessage(msg, tx_can)
-        #print(hex(tx_can.arbitration_id), tx_can.data)
+        # print(hex(tx_can.arbitration_id), tx_can.data)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
 
     def MotionCtrl_2(self, ctrl_mode, move_mode, move_spd_rate_ctrl, is_mit_mode=0x00):
-        '''
+        """
         机械臂运动控制指令2
 
         0x151
@@ -902,57 +1231,72 @@ class C_PiperInterface():
                                     0x01 CAN 指令控制模式 0x02 示教模式 0x03 以太网控制模式 0x04 wifi 控制模式 0x07 离线轨迹模式
         Byte 1 MOVE模式 uint8 0x00 MOVE P
                                     0x01 MOVE J 0x02 MOVE L 0x03 MOVE C
-        Byte 2 运动速度百分比 uint8 0~100 
-        
+        Byte 2 运动速度百分比 uint8 0~100
+
         Byte 3 mit模式 uint8 0x00 位置速度模式
                             0xAD MIT模式
         Byte 4 离线轨迹点停留时间 uint8 0~255 单位 s
-        '''
-        tx_can=Message()
-        motion_ctrl_2 = ArmMsgMotionCtrl_2(ctrl_mode, move_mode, move_spd_rate_ctrl, is_mit_mode)
+        """
+        tx_can = Message()
+        motion_ctrl_2 = ArmMsgMotionCtrl_2(
+            ctrl_mode, move_mode, move_spd_rate_ctrl, is_mit_mode
+        )
         # print(motion_ctrl_1)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgMotionCtrl_2, arm_motion_ctrl_2=motion_ctrl_2)
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgMotionCtrl_2, arm_motion_ctrl_2=motion_ctrl_2
+        )
         self.parser.EncodeMessage(msg, tx_can)
-        #print(hex(tx_can.arbitration_id), tx_can.data)
+        # print(hex(tx_can.arbitration_id), tx_can.data)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
-    
-    def EndPoseCtrl(self,X,Y,Z,RX,RY,RZ):
-        self.__CartesianCtrl_XY(X,Y)
-        self.__CartesianCtrl_ZRX(Z,RX)
-        self.__CartesianCtrl_RYRZ(RY,RZ)
+
+    def EndPoseCtrl(self, X, Y, Z, RX, RY, RZ):
+        self.__CartesianCtrl_XY(X, Y)
+        self.__CartesianCtrl_ZRX(Z, RX)
+        self.__CartesianCtrl_RYRZ(RY, RZ)
 
     def __CartesianCtrl_XY(self, X, Y):
-        tx_can=Message()
+        tx_can = Message()
         cartesian_1 = ArmMsgMotionCtrlCartesian(X_axis=X, Y_axis=Y)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgMotionCtrlCartesian_1, arm_motion_ctrl_cartesian=cartesian_1)
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgMotionCtrlCartesian_1,
+            arm_motion_ctrl_cartesian=cartesian_1,
+        )
         self.parser.EncodeMessage(msg, tx_can)
-        #print(hex(tx_can.arbitration_id), tx_can.data)
-        self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
-    
-    def __CartesianCtrl_ZRX(self, Z, RX):
-        tx_can=Message()
-        cartesian_2 = ArmMsgMotionCtrlCartesian(Z_axis=Z, RX_axis=RX)
-        # print(cartesian_2)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgMotionCtrlCartesian_2, arm_motion_ctrl_cartesian=cartesian_2)
-        self.parser.EncodeMessage(msg, tx_can)
-        #print(hex(tx_can.arbitration_id), tx_can.data)
-        self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
-    
-    def __CartesianCtrl_RYRZ(self, RY, RZ):
-        tx_can=Message()
-        cartesian_3 = ArmMsgMotionCtrlCartesian(RY_axis=RY, RZ_axis=RZ)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgMotionCtrlCartesian_3, arm_motion_ctrl_cartesian=cartesian_3)
-        self.parser.EncodeMessage(msg, tx_can)
-        #print(hex(tx_can.arbitration_id), tx_can.data)
+        # print(hex(tx_can.arbitration_id), tx_can.data)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
 
-    def JointCtrl(self, 
-                  joint_1:int, 
-                  joint_2:int,
-                  joint_3:int,
-                  joint_4:int,
-                  joint_5:int,
-                  joint_6:int):
+    def __CartesianCtrl_ZRX(self, Z, RX):
+        tx_can = Message()
+        cartesian_2 = ArmMsgMotionCtrlCartesian(Z_axis=Z, RX_axis=RX)
+        # print(cartesian_2)
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgMotionCtrlCartesian_2,
+            arm_motion_ctrl_cartesian=cartesian_2,
+        )
+        self.parser.EncodeMessage(msg, tx_can)
+        # print(hex(tx_can.arbitration_id), tx_can.data)
+        self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
+
+    def __CartesianCtrl_RYRZ(self, RY, RZ):
+        tx_can = Message()
+        cartesian_3 = ArmMsgMotionCtrlCartesian(RY_axis=RY, RZ_axis=RZ)
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgMotionCtrlCartesian_3,
+            arm_motion_ctrl_cartesian=cartesian_3,
+        )
+        self.parser.EncodeMessage(msg, tx_can)
+        # print(hex(tx_can.arbitration_id), tx_can.data)
+        self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
+
+    def JointCtrl(
+        self,
+        joint_1: int,
+        joint_2: int,
+        joint_3: int,
+        joint_4: int,
+        joint_5: int,
+        joint_6: int,
+    ):
         """机械臂关节控制
 
         Args:
@@ -966,7 +1310,7 @@ class C_PiperInterface():
         self.__JointCtrl_12(joint_1, joint_2)
         self.__JointCtrl_34(joint_3, joint_4)
         self.__JointCtrl_56(joint_5, joint_6)
-    
+
     def __JointCtrl_12(self, joint_1, joint_2):
         """机械臂1,2关节控制
 
@@ -976,46 +1320,54 @@ class C_PiperInterface():
             joint_1 (_type_): 关节1角度
             joint_2 (_type_): 关节2角度
         """
-        tx_can=Message()
+        tx_can = Message()
         joint_ctrl = ArmMsgJointCtrl(joint_1=joint_1, joint_2=joint_2)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgJointCtrl_12, arm_joint_ctrl=joint_ctrl)
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgJointCtrl_12, arm_joint_ctrl=joint_ctrl
+        )
         self.parser.EncodeMessage(msg, tx_can)
-        #print(hex(tx_can.arbitration_id), tx_can.data)
+        # print(hex(tx_can.arbitration_id), tx_can.data)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
-    
+
     def __JointCtrl_34(self, joint_3, joint_4):
         """机械臂3,4关节控制
-        
+
         私有函数
 
         Args:
             joint_3 (_type_): 关节3角度
             joint_4 (_type_): 关节4角度
         """
-        tx_can=Message()
+        tx_can = Message()
         joint_ctrl = ArmMsgJointCtrl(joint_3=joint_3, joint_4=joint_4)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgJointCtrl_34, arm_joint_ctrl=joint_ctrl)
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgJointCtrl_34, arm_joint_ctrl=joint_ctrl
+        )
         self.parser.EncodeMessage(msg, tx_can)
-        #print(hex(tx_can.arbitration_id), tx_can.data)
+        # print(hex(tx_can.arbitration_id), tx_can.data)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
-    
+
     def __JointCtrl_56(self, joint_5, joint_6):
         """机械臂5,6关节控制
-        
+
         私有函数
 
         Args:
             joint_5 (_type_): 关节5角度
             joint_6 (_type_): 关节6角度
         """
-        tx_can=Message()
+        tx_can = Message()
         joint_ctrl = ArmMsgJointCtrl(joint_5=joint_5, joint_6=joint_6)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgJointCtrl_56, arm_joint_ctrl=joint_ctrl)
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgJointCtrl_56, arm_joint_ctrl=joint_ctrl
+        )
         self.parser.EncodeMessage(msg, tx_can)
-        #print(hex(tx_can.arbitration_id), tx_can.data)
+        # print(hex(tx_can.arbitration_id), tx_can.data)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
 
-    def GripperCtrl(self, gripper_angle:int, gripper_effort:int, gripper_code:int, set_zero:int):
+    def GripperCtrl(
+        self, gripper_angle: int, gripper_effort: int, gripper_code: int, set_zero: int
+    ):
         """夹爪控制
 
         Args:
@@ -1024,27 +1376,41 @@ class C_PiperInterface():
             gripper_code (int): 夹爪使能/失能/清除错误
             set_zero:(int): 设定当前位置为0点
         """
-        tx_can=Message()
-        gripper_ctrl = ArmMsgGripperCtrl(gripper_angle, gripper_effort, gripper_code, set_zero)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgGripperCtrl, arm_gripper_ctrl=gripper_ctrl)
+        tx_can = Message()
+        gripper_ctrl = ArmMsgGripperCtrl(
+            gripper_angle, gripper_effort, gripper_code, set_zero
+        )
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgGripperCtrl, arm_gripper_ctrl=gripper_ctrl
+        )
         self.parser.EncodeMessage(msg, tx_can)
         # print(hex(tx_can.arbitration_id), tx_can.data)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
-    
-    def MasterSlaveConfig(self, linkage_config:int, feedback_offset:int, ctrl_offset:int, linkage_offset:int):
+
+    def MasterSlaveConfig(
+        self,
+        linkage_config: int,
+        feedback_offset: int,
+        ctrl_offset: int,
+        linkage_offset: int,
+    ):
         """随动主从模式设置指令
 
         0x470
-        
+
         Args:
             linkage_config ([0, 250, 252]): 联动设置指令
             feedback_offset ([0, 16, 32]): 反馈指令偏移值
             ctrl_offset ([0, 16, 32]): 控制指令偏移值
             linkage_offset ([0, 16, 32]): 联动模式控制目标地址偏移值
         """
-        tx_can=Message()
-        ms_config = ArmMsgMasterSlaveModeConfig(linkage_config, feedback_offset, ctrl_offset, linkage_offset)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgMasterSlaveModeConfig, arm_ms_config=ms_config)
+        tx_can = Message()
+        ms_config = ArmMsgMasterSlaveModeConfig(
+            linkage_config, feedback_offset, ctrl_offset, linkage_offset
+        )
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgMasterSlaveModeConfig, arm_ms_config=ms_config
+        )
         self.parser.EncodeMessage(msg, tx_can)
         # print(hex(tx_can.arbitration_id), tx_can.data)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
@@ -1053,42 +1419,49 @@ class C_PiperInterface():
         """失能电机
         0x471
         """
-        tx_can=Message()
+        tx_can = Message()
         enable = ArmMsgMotorEnableDisableConfig(motor_num, enable_flag)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgMotorEnableDisableConfig, arm_motor_enable=enable)
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgMotorEnableDisableConfig, arm_motor_enable=enable
+        )
         self.parser.EncodeMessage(msg, tx_can)
         # print(hex(tx_can.arbitration_id), tx_can.data)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
-    
+
     def EnableArm(self, motor_num=0xFF, enable_flag=2):
         """使能电机
         0x471
         """
-        tx_can=Message()
+        tx_can = Message()
         disable = ArmMsgMotorEnableDisableConfig(motor_num, enable_flag)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgMotorEnableDisableConfig, arm_motor_enable=disable)
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgMotorEnableDisableConfig, arm_motor_enable=disable
+        )
         self.parser.EncodeMessage(msg, tx_can)
         # print(hex(tx_can.arbitration_id), tx_can.data)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
 
     def SearchMotorMaxAngleSpdAccLimit(self, motor_num, search_content):
-        '''
+        """
         查询电机角度/最大速度/最大加速度限制指令
 
         对应反馈当前电机限制角度/最大速度
-        
+
         0x472
-        
+
         :Byte 0 motor_num: uint8, 关节电机序号。
                             值域 1-6:
                                 1-6 代表关节驱动器序号
         :Byte 1 search_content: uint8, 查询内容。
                             0x01 : 查询电机角度/最大速度
                             0x02 : 查询电机最大加速度限制
-        '''
-        tx_can=Message()
+        """
+        tx_can = Message()
         search_motor = ArmMsgSearchMotorMaxAngleSpdAccLimit(motor_num, search_content)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgSearchMotorMaxAngleSpdAccLimit, arm_search_motor_max_angle_spd_acc_limit=search_motor)
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgSearchMotorMaxAngleSpdAccLimit,
+            arm_search_motor_max_angle_spd_acc_limit=search_motor,
+        )
         self.parser.EncodeMessage(msg, tx_can)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
 
@@ -1099,7 +1472,7 @@ class C_PiperInterface():
         self.SearchMotorMaxAngleSpdAccLimit(4, 0x01)
         self.SearchMotorMaxAngleSpdAccLimit(5, 0x01)
         self.SearchMotorMaxAngleSpdAccLimit(6, 0x01)
-    
+
     def SearchAllMotorMaxAccLimit(self):
         self.SearchMotorMaxAngleSpdAccLimit(1, 0x02)
         self.SearchMotorMaxAngleSpdAccLimit(2, 0x02)
@@ -1107,45 +1480,70 @@ class C_PiperInterface():
         self.SearchMotorMaxAngleSpdAccLimit(4, 0x02)
         self.SearchMotorMaxAngleSpdAccLimit(5, 0x02)
         self.SearchMotorMaxAngleSpdAccLimit(6, 0x02)
-    
-    def MotorAngleLimitMaxSpdSet(self, motor_num, max_angle_limit, min_angle_limit, max_jonit_spd):
-        '''
+
+    def MotorAngleLimitMaxSpdSet(
+        self, motor_num, max_angle_limit, min_angle_limit, max_jonit_spd
+    ):
+        """
         电机角度限制/最大速度设置指令
         0x474
-        '''
-        tx_can=Message()
-        motor_set = ArmMsgMotorAngleLimitMaxSpdSet(motor_num, max_angle_limit, min_angle_limit, max_jonit_spd)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgMotorAngleLimitMaxSpdSet, arm_motor_angle_limit_max_spd_set=motor_set)
+        """
+        tx_can = Message()
+        motor_set = ArmMsgMotorAngleLimitMaxSpdSet(
+            motor_num, max_angle_limit, min_angle_limit, max_jonit_spd
+        )
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgMotorAngleLimitMaxSpdSet,
+            arm_motor_angle_limit_max_spd_set=motor_set,
+        )
         self.parser.EncodeMessage(msg, tx_can)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
 
-    def JointConfig(self, 
-                    joint_num:Literal[1, 2, 3, 4, 5, 6, 7]=7,
-                    set_zero:Literal[0x00, 0xAE]=0,
-                    acc_param_is_effective:Literal[0x00, 0xAE]=0,
-                    set_acc:int=0,
-                    clear_err:Literal[0x00, 0xAE]=0):
-        '''
+    def JointConfig(
+        self,
+        joint_num: Literal[1, 2, 3, 4, 5, 6, 7] = 7,
+        set_zero: Literal[0x00, 0xAE] = 0,
+        acc_param_is_effective: Literal[0x00, 0xAE] = 0,
+        set_acc: int = 0,
+        clear_err: Literal[0x00, 0xAE] = 0,
+    ):
+        """
         关节设置
-        '''
-        tx_can=Message()
-        joint_config = ArmMsgJointConfig(joint_num, set_zero,acc_param_is_effective,set_acc,clear_err)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgJointConfig,arm_joint_config=joint_config)
+        """
+        tx_can = Message()
+        joint_config = ArmMsgJointConfig(
+            joint_num, set_zero, acc_param_is_effective, set_acc, clear_err
+        )
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgJointConfig, arm_joint_config=joint_config
+        )
         self.parser.EncodeMessage(msg, tx_can)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
-    
+
     def SetInstructionResponse(self, instruction_index, zero_config_success_flag):
-        '''
+        """
         设置指令应答
-        '''
-        tx_can=Message()
-        set_resp = ArmMsgInstructionResponseConfig(instruction_index, zero_config_success_flag)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgInstructionResponseConfig, arm_set_instruction_response=set_resp)
+        """
+        tx_can = Message()
+        set_resp = ArmMsgInstructionResponseConfig(
+            instruction_index, zero_config_success_flag
+        )
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgInstructionResponseConfig,
+            arm_set_instruction_response=set_resp,
+        )
         self.parser.EncodeMessage(msg, tx_can)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
-    
-    def ArmParamEnquiryAndConfig(self, param_enquiry, param_setting, data_feedback_0x48x, end_load_param_setting_effective, set_end_load):
-        '''
+
+    def ArmParamEnquiryAndConfig(
+        self,
+        param_enquiry,
+        param_setting,
+        data_feedback_0x48x,
+        end_load_param_setting_effective,
+        set_end_load,
+    ):
+        """
         机械臂参数查
         询与设置指令
 
@@ -1154,51 +1552,73 @@ class C_PiperInterface():
         param_enquiry Byte 0 = 0x01 ->0x478
 
         param_enquiry Byte 0 = 0x02 ->0x47B
-        '''
-        tx_can=Message()
-        search_set_arm_param = ArmMsgParamEnquiryAndConfig(param_enquiry, 
-                                                           param_setting, 
-                                                           data_feedback_0x48x, 
-                                                           end_load_param_setting_effective,
-                                                           set_end_load)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgParamEnquiryAndConfig, arm_param_enquiry_and_config=search_set_arm_param)
+        """
+        tx_can = Message()
+        search_set_arm_param = ArmMsgParamEnquiryAndConfig(
+            param_enquiry,
+            param_setting,
+            data_feedback_0x48x,
+            end_load_param_setting_effective,
+            set_end_load,
+        )
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgParamEnquiryAndConfig,
+            arm_param_enquiry_and_config=search_set_arm_param,
+        )
         self.parser.EncodeMessage(msg, tx_can)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
-    
-    def EndSpdAndAccParamSet(self, end_max_linear_vel, end_max_angular_vel, end_max_linear_acc, end_max_angular_acc):
-        '''
+
+    def EndSpdAndAccParamSet(
+        self,
+        end_max_linear_vel,
+        end_max_angular_vel,
+        end_max_linear_acc,
+        end_max_angular_acc,
+    ):
+        """
         末端速度/加
         速度参数设置
         指令
-        '''
-        tx_can=Message()
-        end_set = ArmMsgEndVelAccParamConfig(end_max_linear_vel, 
-                                            end_max_angular_vel, 
-                                            end_max_linear_acc, 
-                                            end_max_angular_acc,)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgEndVelAccParamConfig, arm_end_vel_acc_param_config=end_set)
+        """
+        tx_can = Message()
+        end_set = ArmMsgEndVelAccParamConfig(
+            end_max_linear_vel,
+            end_max_angular_vel,
+            end_max_linear_acc,
+            end_max_angular_acc,
+        )
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgEndVelAccParamConfig,
+            arm_end_vel_acc_param_config=end_set,
+        )
         self.parser.EncodeMessage(msg, tx_can)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
 
-    def CrashProtectionConfig(self, 
-                              jonit_1_protection_level, 
-                              jonit_2_protection_level, 
-                              jonit_3_protection_level, 
-                              jonit_4_protection_level,
-                              jonit_5_protection_level,
-                              jonit_6_protection_level):
-        '''
+    def CrashProtectionConfig(
+        self,
+        jonit_1_protection_level,
+        jonit_2_protection_level,
+        jonit_3_protection_level,
+        jonit_4_protection_level,
+        jonit_5_protection_level,
+        jonit_6_protection_level,
+    ):
+        """
         碰撞防护等级
         设置指令
-        '''
-        tx_can=Message()
-        crash_config = ArmMsgCrashProtectionRatingConfig(jonit_1_protection_level, 
-                                                        jonit_2_protection_level, 
-                                                        jonit_3_protection_level, 
-                                                        jonit_4_protection_level,
-                                                        jonit_5_protection_level,
-                                                        jonit_6_protection_level)
-        msg = PiperMessage(type_=ArmMsgType.PiperMsgCrashProtectionRatingConfig, arm_crash_protection_rating_config=crash_config)
+        """
+        tx_can = Message()
+        crash_config = ArmMsgCrashProtectionRatingConfig(
+            jonit_1_protection_level,
+            jonit_2_protection_level,
+            jonit_3_protection_level,
+            jonit_4_protection_level,
+            jonit_5_protection_level,
+            jonit_6_protection_level,
+        )
+        msg = PiperMessage(
+            type_=ArmMsgType.PiperMsgCrashProtectionRatingConfig,
+            arm_crash_protection_rating_config=crash_config,
+        )
         self.parser.EncodeMessage(msg, tx_can)
         self.arm_can.SendCanMessage(tx_can.arbitration_id, tx_can.data)
-

--- a/piper_msgs/msg_v1/__init__.py
+++ b/piper_msgs/msg_v1/__init__.py
@@ -7,17 +7,31 @@ from .arm_messages import PiperMessage
 from .can_id import CanIDPiper
 from .arm_msg_type import ArmMsgType
 from .arm_id_type_map import ArmMessageMapping
+
 # 导入 feedback 子模块的类
 from .feedback.arm_end_pose import ArmMsgEndPoseFeedBack
 from .feedback.arm_joint_feedback import ArmMsgJointFeedBack
 from .feedback.arm_status import ArmMsgStatus
 from .feedback.gripper_feedback import ArmMsgGripperFeedBack
-from .feedback.arm_feedback_current_motor_angle_limit_max_spd import ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd, ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd
-from .feedback.arm_feedback_current_end_vel_acc_param import ArmMsgFeedbackCurrentEndVelAccParam
-from .feedback.arm_feedback_current_motor_max_acc_limit import ArmMsgFeedbackCurrentMotorMaxAccLimit, ArmMsgFeedbackAllCurrentMotorMaxAccLimit
-from .feedback.arm_feedback_joint_vel_acc import ArmMsgFeedbackJointVelAcc, ArmMsgFeedbackAllJointVelAcc
+from .feedback.arm_feedback_current_motor_angle_limit_max_spd import (
+    ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd,
+    ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd,
+)
+from .feedback.arm_feedback_current_end_vel_acc_param import (
+    ArmMsgFeedbackCurrentEndVelAccParam,
+)
+from .feedback.arm_feedback_current_motor_max_acc_limit import (
+    ArmMsgFeedbackCurrentMotorMaxAccLimit,
+    ArmMsgFeedbackAllCurrentMotorMaxAccLimit,
+)
+from .feedback.arm_feedback_joint_vel_acc import (
+    ArmMsgFeedbackJointVelAcc,
+    ArmMsgFeedbackAllJointVelAcc,
+)
 
-from .feedback.arm_crash_protection_rating_feedback import ArmMsgCrashProtectionRatingFeedback
+from .feedback.arm_crash_protection_rating_feedback import (
+    ArmMsgCrashProtectionRatingFeedback,
+)
 from .feedback.arm_high_spd_feedback import ArmHighSpdFeedback
 from .feedback.arm_low_spd_feedback import ArmLowSpdFeedback
 
@@ -30,49 +44,54 @@ from .transmit.arm_circular_pattern import ArmMsgCircularPatternCoordNumUpdateCt
 from .transmit.arm_gripper_ctrl import ArmMsgGripperCtrl
 from .transmit.arm_master_slave_config import ArmMsgMasterSlaveModeConfig
 from .transmit.arm_motor_enable_disable import ArmMsgMotorEnableDisableConfig
-from .transmit.arm_search_motor_max_angle_spd_acc_limit import ArmMsgSearchMotorMaxAngleSpdAccLimit
-from .transmit.arm_motor_angle_limit_max_spd_config import ArmMsgMotorAngleLimitMaxSpdSet
+from .transmit.arm_search_motor_max_angle_spd_acc_limit import (
+    ArmMsgSearchMotorMaxAngleSpdAccLimit,
+)
+from .transmit.arm_motor_angle_limit_max_spd_config import (
+    ArmMsgMotorAngleLimitMaxSpdSet,
+)
 from .transmit.arm_joint_config import ArmMsgJointConfig
 from .transmit.arm_set_instruction_response import ArmMsgInstructionResponseConfig
 from .transmit.arm_param_enquiry_and_config import ArmMsgParamEnquiryAndConfig
 from .transmit.arm_end_vel_acc_param_config import ArmMsgEndVelAccParamConfig
-from .transmit.arm_crash_protection_rating_config import ArmMsgCrashProtectionRatingConfig
+from .transmit.arm_crash_protection_rating_config import (
+    ArmMsgCrashProtectionRatingConfig,
+)
 
 # 定义 __all__ 使得 from msg_v1 import * 可以导入这些类
 __all__ = [
     # 反馈
-    'PiperMessage',
-    'CanIDPiper',
-    'ArmMsgEndPoseFeedBack',
-    'ArmMsgJointFeedBack',
-    'ArmMsgType',
-    'ArmMsgStatus',
-    'ArmMsgGripperFeedBack',
-    'ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd',
-    'ArmMsgFeedbackCurrentEndVelAccParam',
-    'ArmMsgFeedbackCurrentMotorMaxAccLimit',
-    'ArmMsgFeedbackJointVelAcc',
-    'ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd',
-    'ArmMsgFeedbackAllCurrentMotorMaxAccLimit',
-    'ArmMsgFeedbackAllJointVelAcc',
-    'ArmMsgCrashProtectionRatingFeedback',
-    'ArmHighSpdFeedback',
-    'ArmLowSpdFeedback',
+    "PiperMessage",
+    "CanIDPiper",
+    "ArmMsgEndPoseFeedBack",
+    "ArmMsgJointFeedBack",
+    "ArmMsgType",
+    "ArmMsgStatus",
+    "ArmMsgGripperFeedBack",
+    "ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd",
+    "ArmMsgFeedbackCurrentEndVelAccParam",
+    "ArmMsgFeedbackCurrentMotorMaxAccLimit",
+    "ArmMsgFeedbackJointVelAcc",
+    "ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd",
+    "ArmMsgFeedbackAllCurrentMotorMaxAccLimit",
+    "ArmMsgFeedbackAllJointVelAcc",
+    "ArmMsgCrashProtectionRatingFeedback",
+    "ArmHighSpdFeedback",
+    "ArmLowSpdFeedback",
     # 发送
-    'ArmMsgMotionCtrl_1',
-    'ArmMsgMotionCtrl_2',
-    'ArmMsgMotionCtrlCartesian',
-    'ArmMsgJointCtrl',
-    'ArmMsgCircularPatternCoordNumUpdateCtrl',
-    'ArmMsgGripperCtrl',
-    'ArmMsgMasterSlaveModeConfig',
-    'ArmMsgMotorEnableDisableConfig',
-    'ArmMsgSearchMotorMaxAngleSpdAccLimit',
-    'ArmMsgMotorAngleLimitMaxSpdSet',
-    'ArmMsgJointConfig',
-    'ArmMsgInstructionResponseConfig',
-    'ArmMsgParamEnquiryAndConfig',
-    'ArmMsgEndVelAccParamConfig',
-    'ArmMsgCrashProtectionRatingConfig'
+    "ArmMsgMotionCtrl_1",
+    "ArmMsgMotionCtrl_2",
+    "ArmMsgMotionCtrlCartesian",
+    "ArmMsgJointCtrl",
+    "ArmMsgCircularPatternCoordNumUpdateCtrl",
+    "ArmMsgGripperCtrl",
+    "ArmMsgMasterSlaveModeConfig",
+    "ArmMsgMotorEnableDisableConfig",
+    "ArmMsgSearchMotorMaxAngleSpdAccLimit",
+    "ArmMsgMotorAngleLimitMaxSpdSet",
+    "ArmMsgJointConfig",
+    "ArmMsgInstructionResponseConfig",
+    "ArmMsgParamEnquiryAndConfig",
+    "ArmMsgEndVelAccParamConfig",
+    "ArmMsgCrashProtectionRatingConfig",
 ]
-

--- a/piper_msgs/msg_v1/arm_id_type_map.py
+++ b/piper_msgs/msg_v1/arm_id_type_map.py
@@ -7,10 +7,11 @@ from typing import (
 from .arm_msg_type import ArmMsgType
 from .can_id import CanIDPiper
 
+
 class ArmMessageMapping:
-    '''
+    """
     机械臂消息类型和CAN ID的映射
-    '''
+    """
 
     # 初始化映射字典
     id_to_type_mapping = {
@@ -85,13 +86,15 @@ class ArmMessageMapping:
     type_to_id_mapping = {v: k for k, v in id_to_type_mapping.items()}
 
     @staticmethod
-    def get_mapping(can_id: Optional[int] = None, msg_type: Optional[ArmMsgType] = None):
-        '''
+    def get_mapping(
+        can_id: Optional[int] = None, msg_type: Optional[ArmMsgType] = None
+    ):
+        """
         根据输入的参数返回对应的映射值，输入 id 返回类型，输入类型返回 id
         :param can_id: CAN ID
         :param msg_type: 机械臂消息类型
         :return: 对应的类型或 id
-        '''
+        """
         if can_id is not None and msg_type is not None:
             raise ValueError("只能输入 CAN ID 或消息类型中的一个")
 
@@ -108,6 +111,7 @@ class ArmMessageMapping:
                 raise ValueError(f"消息类型 {msg_type} 不在映射中")
 
         raise ValueError("必须输入 CAN ID 或消息类型中的一个")
+
 
 # 测试代码
 # if __name__ == "__main__":

--- a/piper_msgs/msg_v1/arm_messages.py
+++ b/piper_msgs/msg_v1/arm_messages.py
@@ -15,10 +15,21 @@ from .feedback.arm_end_pose import ArmMsgEndPoseFeedBack
 from .feedback.arm_joint_feedback import ArmMsgJointFeedBack
 from .feedback.arm_status import ArmMsgStatus
 from .feedback.gripper_feedback import ArmMsgGripperFeedBack
-from .feedback.arm_feedback_current_end_vel_acc_param import ArmMsgFeedbackCurrentEndVelAccParam
-from .feedback.arm_feedback_current_motor_angle_limit_max_spd import ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd, ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd
-from .feedback.arm_feedback_current_motor_max_acc_limit import ArmMsgFeedbackCurrentMotorMaxAccLimit, ArmMsgFeedbackAllCurrentMotorMaxAccLimit
-from .feedback.arm_feedback_joint_vel_acc import ArmMsgFeedbackJointVelAcc, ArmMsgFeedbackAllJointVelAcc
+from .feedback.arm_feedback_current_end_vel_acc_param import (
+    ArmMsgFeedbackCurrentEndVelAccParam,
+)
+from .feedback.arm_feedback_current_motor_angle_limit_max_spd import (
+    ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd,
+    ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd,
+)
+from .feedback.arm_feedback_current_motor_max_acc_limit import (
+    ArmMsgFeedbackCurrentMotorMaxAccLimit,
+    ArmMsgFeedbackAllCurrentMotorMaxAccLimit,
+)
+from .feedback.arm_feedback_joint_vel_acc import (
+    ArmMsgFeedbackJointVelAcc,
+    ArmMsgFeedbackAllJointVelAcc,
+)
 from .feedback.arm_high_spd_feedback import ArmHighSpdFeedback
 from .feedback.arm_low_spd_feedback import ArmLowSpdFeedback
 
@@ -30,122 +41,208 @@ from .transmit.arm_circular_pattern import ArmMsgCircularPatternCoordNumUpdateCt
 from .transmit.arm_gripper_ctrl import ArmMsgGripperCtrl
 from .transmit.arm_master_slave_config import ArmMsgMasterSlaveModeConfig
 from .transmit.arm_motor_enable_disable import ArmMsgMotorEnableDisableConfig
-from .transmit.arm_search_motor_max_angle_spd_acc_limit import ArmMsgSearchMotorMaxAngleSpdAccLimit
-from .transmit.arm_motor_angle_limit_max_spd_config import ArmMsgMotorAngleLimitMaxSpdSet
+from .transmit.arm_search_motor_max_angle_spd_acc_limit import (
+    ArmMsgSearchMotorMaxAngleSpdAccLimit,
+)
+from .transmit.arm_motor_angle_limit_max_spd_config import (
+    ArmMsgMotorAngleLimitMaxSpdSet,
+)
 from .transmit.arm_joint_config import ArmMsgJointConfig
 from .transmit.arm_set_instruction_response import ArmMsgInstructionResponseConfig
 from .transmit.arm_param_enquiry_and_config import ArmMsgParamEnquiryAndConfig
 from .transmit.arm_end_vel_acc_param_config import ArmMsgEndVelAccParamConfig
-from .transmit.arm_crash_protection_rating_config import ArmMsgCrashProtectionRatingConfig
-from .feedback.arm_crash_protection_rating_feedback import ArmMsgCrashProtectionRatingFeedback
+from .transmit.arm_crash_protection_rating_config import (
+    ArmMsgCrashProtectionRatingConfig,
+)
+from .feedback.arm_crash_protection_rating_feedback import (
+    ArmMsgCrashProtectionRatingFeedback,
+)
+
 
 class PiperMessage:
-    '''
+    """
     Piper机械臂全部消息,为所有消息的汇总
-    '''
-    
-    def __init__(self, 
-                #  反馈
-                 type_: 'ArmMsgType' = None,
-                 arm_status_msgs: 'ArmMsgStatus' = None,
-                 arm_joint_feedback: 'ArmMsgJointFeedBack' = None,
-                 gripper_feedback: 'ArmMsgGripperFeedBack' = None,
-                 arm_end_pose: 'ArmMsgEndPoseFeedBack'=None,
-                 arm_feedback_current_motor_angle_limit_max_spd:'ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd'=None,
-                 arm_feedback_current_end_vel_acc_param:'ArmMsgFeedbackCurrentEndVelAccParam'=None,
-                 arm_feedback_current_motor_max_acc_limit:'ArmMsgFeedbackCurrentMotorMaxAccLimit'=None,
-                 arm_crash_protection_rating_feedback:'ArmMsgCrashProtectionRatingFeedback'=None,
-                 #  arm_feedback_joint_vel_acc:'ArmMsgFeedbackJointVelAcc'=None
-                #  arm_feedback_all_current_motor_angle_limit_max_spd:'ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd'=None,
-                #  arm_feedback_all_motor_max_acc_limit:'ArmMsgFeedbackAllCurrentMotorMaxAccLimit'=None,
-                 arm_high_spd_feedback:'ArmHighSpdFeedback'=None,
-                 arm_low_spd_feedback:'ArmLowSpdFeedback'=None,
-                #  发送
-                 arm_motion_ctrl_1: 'ArmMsgMotionCtrl_1'=None,
-                 arm_motion_ctrl_2: 'ArmMsgMotionCtrl_2'=None,
-                 arm_motion_ctrl_cartesian: 'ArmMsgMotionCtrlCartesian'=None,
-                 arm_joint_ctrl: 'ArmMsgJointCtrl'=None,
-                 arm_circular_ctrl: 'ArmMsgCircularPatternCoordNumUpdateCtrl'=None,
-                 arm_gripper_ctrl: 'ArmMsgGripperCtrl'=None,
-                 arm_ms_config: 'ArmMsgMasterSlaveModeConfig'=None,
-                 arm_motor_enable: 'ArmMsgMotorEnableDisableConfig'=None,
-                 arm_search_motor_max_angle_spd_acc_limit:'ArmMsgSearchMotorMaxAngleSpdAccLimit'=None,
-                 arm_motor_angle_limit_max_spd_set:'ArmMsgMotorAngleLimitMaxSpdSet'=None,
-                 arm_joint_config:'ArmMsgJointConfig'=None,
-                 arm_set_instruction_response:'ArmMsgInstructionResponseConfig'=None,
-                 arm_param_enquiry_and_config:'ArmMsgParamEnquiryAndConfig'=None,
-                 arm_end_vel_acc_param_config:'ArmMsgEndVelAccParamConfig'=None,
-                 arm_crash_protection_rating_config:'ArmMsgCrashProtectionRatingConfig'=None
-                 ):
-        #-------------------------------反馈-------------------------------------------
+    """
+
+    def __init__(
+        self,
+        #  反馈
+        type_: "ArmMsgType" = None,
+        arm_status_msgs: "ArmMsgStatus" = None,
+        arm_joint_feedback: "ArmMsgJointFeedBack" = None,
+        gripper_feedback: "ArmMsgGripperFeedBack" = None,
+        arm_end_pose: "ArmMsgEndPoseFeedBack" = None,
+        arm_feedback_current_motor_angle_limit_max_spd: "ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd" = None,
+        arm_feedback_current_end_vel_acc_param: "ArmMsgFeedbackCurrentEndVelAccParam" = None,
+        arm_feedback_current_motor_max_acc_limit: "ArmMsgFeedbackCurrentMotorMaxAccLimit" = None,
+        arm_crash_protection_rating_feedback: "ArmMsgCrashProtectionRatingFeedback" = None,
+        #  arm_feedback_joint_vel_acc:'ArmMsgFeedbackJointVelAcc'=None
+        #  arm_feedback_all_current_motor_angle_limit_max_spd:'ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd'=None,
+        #  arm_feedback_all_motor_max_acc_limit:'ArmMsgFeedbackAllCurrentMotorMaxAccLimit'=None,
+        arm_high_spd_feedback: "ArmHighSpdFeedback" = None,
+        arm_low_spd_feedback: "ArmLowSpdFeedback" = None,
+        #  发送
+        arm_motion_ctrl_1: "ArmMsgMotionCtrl_1" = None,
+        arm_motion_ctrl_2: "ArmMsgMotionCtrl_2" = None,
+        arm_motion_ctrl_cartesian: "ArmMsgMotionCtrlCartesian" = None,
+        arm_joint_ctrl: "ArmMsgJointCtrl" = None,
+        arm_circular_ctrl: "ArmMsgCircularPatternCoordNumUpdateCtrl" = None,
+        arm_gripper_ctrl: "ArmMsgGripperCtrl" = None,
+        arm_ms_config: "ArmMsgMasterSlaveModeConfig" = None,
+        arm_motor_enable: "ArmMsgMotorEnableDisableConfig" = None,
+        arm_search_motor_max_angle_spd_acc_limit: "ArmMsgSearchMotorMaxAngleSpdAccLimit" = None,
+        arm_motor_angle_limit_max_spd_set: "ArmMsgMotorAngleLimitMaxSpdSet" = None,
+        arm_joint_config: "ArmMsgJointConfig" = None,
+        arm_set_instruction_response: "ArmMsgInstructionResponseConfig" = None,
+        arm_param_enquiry_and_config: "ArmMsgParamEnquiryAndConfig" = None,
+        arm_end_vel_acc_param_config: "ArmMsgEndVelAccParamConfig" = None,
+        arm_crash_protection_rating_config: "ArmMsgCrashProtectionRatingConfig" = None,
+    ):
+        # -------------------------------反馈-------------------------------------------
         # 初始化数据帧类型
         self.type_ = type_
         # 初始化机械臂状态消息
         self.arm_status_msgs = arm_status_msgs if arm_status_msgs else ArmMsgStatus()
         # 初始化机械臂关节反馈
-        self.arm_joint_feedback = arm_joint_feedback if arm_joint_feedback else ArmMsgJointFeedBack()
+        self.arm_joint_feedback = (
+            arm_joint_feedback if arm_joint_feedback else ArmMsgJointFeedBack()
+        )
         # 初始化夹爪反馈
-        self.gripper_feedback = gripper_feedback if gripper_feedback else ArmMsgGripperFeedBack()
+        self.gripper_feedback = (
+            gripper_feedback if gripper_feedback else ArmMsgGripperFeedBack()
+        )
         # 初始化末端姿态反馈
         self.arm_end_pose = arm_end_pose if arm_end_pose else ArmMsgEndPoseFeedBack()
         # 驱动器信息高速反馈
-        self.arm_high_spd_feedback_1 = arm_high_spd_feedback if arm_high_spd_feedback else ArmHighSpdFeedback()
-        self.arm_high_spd_feedback_2 = arm_high_spd_feedback if arm_high_spd_feedback else ArmHighSpdFeedback()
-        self.arm_high_spd_feedback_3 = arm_high_spd_feedback if arm_high_spd_feedback else ArmHighSpdFeedback()
-        self.arm_high_spd_feedback_4 = arm_high_spd_feedback if arm_high_spd_feedback else ArmHighSpdFeedback()
-        self.arm_high_spd_feedback_5 = arm_high_spd_feedback if arm_high_spd_feedback else ArmHighSpdFeedback()
-        self.arm_high_spd_feedback_6 = arm_high_spd_feedback if arm_high_spd_feedback else ArmHighSpdFeedback()
+        self.arm_high_spd_feedback_1 = (
+            arm_high_spd_feedback if arm_high_spd_feedback else ArmHighSpdFeedback()
+        )
+        self.arm_high_spd_feedback_2 = (
+            arm_high_spd_feedback if arm_high_spd_feedback else ArmHighSpdFeedback()
+        )
+        self.arm_high_spd_feedback_3 = (
+            arm_high_spd_feedback if arm_high_spd_feedback else ArmHighSpdFeedback()
+        )
+        self.arm_high_spd_feedback_4 = (
+            arm_high_spd_feedback if arm_high_spd_feedback else ArmHighSpdFeedback()
+        )
+        self.arm_high_spd_feedback_5 = (
+            arm_high_spd_feedback if arm_high_spd_feedback else ArmHighSpdFeedback()
+        )
+        self.arm_high_spd_feedback_6 = (
+            arm_high_spd_feedback if arm_high_spd_feedback else ArmHighSpdFeedback()
+        )
         # 驱动器信息低速反馈
-        self.arm_low_spd_feedback_1 = arm_low_spd_feedback if arm_low_spd_feedback else ArmLowSpdFeedback()
-        self.arm_low_spd_feedback_2 = arm_low_spd_feedback if arm_low_spd_feedback else ArmLowSpdFeedback()
-        self.arm_low_spd_feedback_3 = arm_low_spd_feedback if arm_low_spd_feedback else ArmLowSpdFeedback()
-        self.arm_low_spd_feedback_4 = arm_low_spd_feedback if arm_low_spd_feedback else ArmLowSpdFeedback()
-        self.arm_low_spd_feedback_5 = arm_low_spd_feedback if arm_low_spd_feedback else ArmLowSpdFeedback()
-        self.arm_low_spd_feedback_6 = arm_low_spd_feedback if arm_low_spd_feedback else ArmLowSpdFeedback()
-        #-------------------------------发送-------------------------------------------
-        self.arm_motion_ctrl_1 = arm_motion_ctrl_1 if arm_motion_ctrl_1 else ArmMsgMotionCtrl_1()
-        self.arm_motion_ctrl_2 = arm_motion_ctrl_2 if arm_motion_ctrl_2 else ArmMsgMotionCtrl_2()
-        self.arm_motion_ctrl_cartesian = arm_motion_ctrl_cartesian if arm_motion_ctrl_cartesian else ArmMsgMotionCtrlCartesian()
+        self.arm_low_spd_feedback_1 = (
+            arm_low_spd_feedback if arm_low_spd_feedback else ArmLowSpdFeedback()
+        )
+        self.arm_low_spd_feedback_2 = (
+            arm_low_spd_feedback if arm_low_spd_feedback else ArmLowSpdFeedback()
+        )
+        self.arm_low_spd_feedback_3 = (
+            arm_low_spd_feedback if arm_low_spd_feedback else ArmLowSpdFeedback()
+        )
+        self.arm_low_spd_feedback_4 = (
+            arm_low_spd_feedback if arm_low_spd_feedback else ArmLowSpdFeedback()
+        )
+        self.arm_low_spd_feedback_5 = (
+            arm_low_spd_feedback if arm_low_spd_feedback else ArmLowSpdFeedback()
+        )
+        self.arm_low_spd_feedback_6 = (
+            arm_low_spd_feedback if arm_low_spd_feedback else ArmLowSpdFeedback()
+        )
+        # -------------------------------发送-------------------------------------------
+        self.arm_motion_ctrl_1 = (
+            arm_motion_ctrl_1 if arm_motion_ctrl_1 else ArmMsgMotionCtrl_1()
+        )
+        self.arm_motion_ctrl_2 = (
+            arm_motion_ctrl_2 if arm_motion_ctrl_2 else ArmMsgMotionCtrl_2()
+        )
+        self.arm_motion_ctrl_cartesian = (
+            arm_motion_ctrl_cartesian
+            if arm_motion_ctrl_cartesian
+            else ArmMsgMotionCtrlCartesian()
+        )
         self.arm_joint_ctrl = arm_joint_ctrl if arm_joint_ctrl else ArmMsgJointCtrl()
-        self.arm_circular_ctrl = arm_circular_ctrl \
-            if arm_circular_ctrl else ArmMsgCircularPatternCoordNumUpdateCtrl()
-        self.arm_gripper_ctrl = arm_gripper_ctrl if arm_gripper_ctrl else ArmMsgGripperCtrl()
-        self.arm_ms_config = arm_ms_config if arm_ms_config else ArmMsgMasterSlaveModeConfig()
+        self.arm_circular_ctrl = (
+            arm_circular_ctrl
+            if arm_circular_ctrl
+            else ArmMsgCircularPatternCoordNumUpdateCtrl()
+        )
+        self.arm_gripper_ctrl = (
+            arm_gripper_ctrl if arm_gripper_ctrl else ArmMsgGripperCtrl()
+        )
+        self.arm_ms_config = (
+            arm_ms_config if arm_ms_config else ArmMsgMasterSlaveModeConfig()
+        )
         # 电机使能/失能设置指令
-        self.arm_motor_enable = arm_motor_enable if arm_motor_enable else ArmMsgMotorEnableDisableConfig()
+        self.arm_motor_enable = (
+            arm_motor_enable if arm_motor_enable else ArmMsgMotorEnableDisableConfig()
+        )
         # 查询电机角度/最大速度/最大加速度限制指令
-        self.arm_search_motor_max_angle_spd_acc_limit = arm_search_motor_max_angle_spd_acc_limit \
-            if arm_search_motor_max_angle_spd_acc_limit else ArmMsgSearchMotorMaxAngleSpdAccLimit()
+        self.arm_search_motor_max_angle_spd_acc_limit = (
+            arm_search_motor_max_angle_spd_acc_limit
+            if arm_search_motor_max_angle_spd_acc_limit
+            else ArmMsgSearchMotorMaxAngleSpdAccLimit()
+        )
         # 反馈当前电机限制角度/最大速度
-        self.arm_feedback_current_motor_angle_limit_max_spd = arm_feedback_current_motor_angle_limit_max_spd \
-            if arm_feedback_current_motor_angle_limit_max_spd else ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd()
+        self.arm_feedback_current_motor_angle_limit_max_spd = (
+            arm_feedback_current_motor_angle_limit_max_spd
+            if arm_feedback_current_motor_angle_limit_max_spd
+            else ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd()
+        )
         # 电机角度限制/最大速度设置指令
-        self.arm_motor_angle_limit_max_spd_set = arm_motor_angle_limit_max_spd_set \
-            if arm_motor_angle_limit_max_spd_set else ArmMsgMotorAngleLimitMaxSpdSet()
+        self.arm_motor_angle_limit_max_spd_set = (
+            arm_motor_angle_limit_max_spd_set
+            if arm_motor_angle_limit_max_spd_set
+            else ArmMsgMotorAngleLimitMaxSpdSet()
+        )
         # 关节设置指令
-        self.arm_joint_config = arm_joint_config \
-            if arm_joint_config else ArmMsgJointConfig()
+        self.arm_joint_config = (
+            arm_joint_config if arm_joint_config else ArmMsgJointConfig()
+        )
         # 设置指令应答
-        self.arm_set_instruction_response = arm_set_instruction_response \
-            if arm_set_instruction_response else ArmMsgInstructionResponseConfig()
+        self.arm_set_instruction_response = (
+            arm_set_instruction_response
+            if arm_set_instruction_response
+            else ArmMsgInstructionResponseConfig()
+        )
         # 机械臂参数查询与设置指令
-        self.arm_param_enquiry_and_config = arm_param_enquiry_and_config \
-            if arm_param_enquiry_and_config else ArmMsgParamEnquiryAndConfig()
+        self.arm_param_enquiry_and_config = (
+            arm_param_enquiry_and_config
+            if arm_param_enquiry_and_config
+            else ArmMsgParamEnquiryAndConfig()
+        )
         # 反馈当前末端速度/加速度参数
-        self.arm_feedback_current_end_vel_acc_param = arm_feedback_current_end_vel_acc_param \
-            if arm_feedback_current_end_vel_acc_param else ArmMsgFeedbackCurrentEndVelAccParam()
+        self.arm_feedback_current_end_vel_acc_param = (
+            arm_feedback_current_end_vel_acc_param
+            if arm_feedback_current_end_vel_acc_param
+            else ArmMsgFeedbackCurrentEndVelAccParam()
+        )
         # 末端速度/加速度参数设置指令
-        self.arm_end_vel_acc_param_config = arm_end_vel_acc_param_config \
-            if arm_end_vel_acc_param_config else ArmMsgEndVelAccParamConfig()
+        self.arm_end_vel_acc_param_config = (
+            arm_end_vel_acc_param_config
+            if arm_end_vel_acc_param_config
+            else ArmMsgEndVelAccParamConfig()
+        )
         # 碰撞防护等级设置指令
-        self.arm_crash_protection_rating_config = arm_crash_protection_rating_config \
-            if arm_crash_protection_rating_config else ArmMsgCrashProtectionRatingConfig()
+        self.arm_crash_protection_rating_config = (
+            arm_crash_protection_rating_config
+            if arm_crash_protection_rating_config
+            else ArmMsgCrashProtectionRatingConfig()
+        )
         # 碰撞防护等级设置反馈指令
-        self.arm_crash_protection_rating_feedback = arm_crash_protection_rating_feedback \
-            if arm_crash_protection_rating_feedback else ArmMsgCrashProtectionRatingFeedback()
+        self.arm_crash_protection_rating_feedback = (
+            arm_crash_protection_rating_feedback
+            if arm_crash_protection_rating_feedback
+            else ArmMsgCrashProtectionRatingFeedback()
+        )
         # 反馈当前电机最大加速度限制
-        self.arm_feedback_current_motor_max_acc_limit = arm_feedback_current_motor_max_acc_limit \
-            if arm_feedback_current_motor_max_acc_limit else ArmMsgFeedbackCurrentMotorMaxAccLimit()
+        self.arm_feedback_current_motor_max_acc_limit = (
+            arm_feedback_current_motor_max_acc_limit
+            if arm_feedback_current_motor_max_acc_limit
+            else ArmMsgFeedbackCurrentMotorMaxAccLimit()
+        )
         # 反馈各个关节当前末端速度/加速度
         # self.arm_feedback_joint_vel_acc = arm_feedback_joint_vel_acc \
         #     if arm_feedback_joint_vel_acc else ArmMsgFeedbackJointVelAcc()
@@ -157,67 +254,121 @@ class PiperMessage:
         #     if arm_feedback_all_motor_max_acc_limit else ArmMsgFeedbackAllCurrentMotorMaxAccLimit()
 
     def __str__(self):
-        if(self.type_ == ArmMsgType.PiperMsgStatusFeedback):
-            return (f"Type: {self.type_}\n"f"Arm Status: {self.arm_status_msgs}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgJointFeedBack_12):
-            return (f"Type: {self.type_}\n"f"Joint Feed: {self.arm_joint_feedback}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgJointFeedBack_34):
-            return (f"Type: {self.type_}\n"f"Joint Feed: {self.arm_joint_feedback}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgJointFeedBack_56):
-            return (f"Type: {self.type_}\n"f"Joint Feed: {self.arm_joint_feedback}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgGripperFeedBack):
-            return (f"Type: {self.type_}\n"f"Gripper Feed: {self.gripper_feedback}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgEndPoseFeedback_1):
-            return (f"Type: {self.type_}\n"f"End Pose Feed: {self.arm_end_pose}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgEndPoseFeedback_2):
-            return (f"Type: {self.type_}\n"f"End Pose Feed: {self.arm_end_pose}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgEndPoseFeedback_3):
-            return (f"Type: {self.type_}\n"f"End Pose Feed: {self.arm_end_pose}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgHighSpdFeed_1):
-            return (f"Type: {self.type_}\n"f"High Spd Feedback: {self.arm_high_spd_feedback_1}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgHighSpdFeed_2):
-            return (f"Type: {self.type_}\n"f"High Spd Feedback: {self.arm_high_spd_feedback_2}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgHighSpdFeed_3):
-            return (f"Type: {self.type_}\n"f"High Spd Feedback: {self.arm_high_spd_feedback_3}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgHighSpdFeed_4):
-            return (f"Type: {self.type_}\n"f"High Spd Feedback: {self.arm_high_spd_feedback_4}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgHighSpdFeed_5):
-            return (f"Type: {self.type_}\n"f"High Spd Feedback: {self.arm_high_spd_feedback_5}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgHighSpdFeed_6):
-            return (f"Type: {self.type_}\n"f"High Spd Feedback: {self.arm_high_spd_feedback_6}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgLowSpdFeed_1):
-            return (f"Type: {self.type_}\n"f"Low Spd Feedback: {self.arm_low_spd_feedback_1}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgLowSpdFeed_2):
-            return (f"Type: {self.type_}\n"f"Low Spd Feedback: {self.arm_low_spd_feedback_2}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgLowSpdFeed_3):
-            return (f"Type: {self.type_}\n"f"Low Spd Feedback: {self.arm_low_spd_feedback_3}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgLowSpdFeed_4):
-            return (f"Type: {self.type_}\n"f"Low Spd Feedback: {self.arm_low_spd_feedback_4}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgLowSpdFeed_5):
-            return (f"Type: {self.type_}\n"f"Low Spd Feedback: {self.arm_low_spd_feedback_5}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgLowSpdFeed_6):
-            return (f"Type: {self.type_}\n"f"Low Spd Feedback: {self.arm_low_spd_feedback_6}\n")
+        if self.type_ == ArmMsgType.PiperMsgStatusFeedback:
+            return f"Type: {self.type_}\n" f"Arm Status: {self.arm_status_msgs}\n"
+        elif self.type_ == ArmMsgType.PiperMsgJointFeedBack_12:
+            return f"Type: {self.type_}\n" f"Joint Feed: {self.arm_joint_feedback}\n"
+        elif self.type_ == ArmMsgType.PiperMsgJointFeedBack_34:
+            return f"Type: {self.type_}\n" f"Joint Feed: {self.arm_joint_feedback}\n"
+        elif self.type_ == ArmMsgType.PiperMsgJointFeedBack_56:
+            return f"Type: {self.type_}\n" f"Joint Feed: {self.arm_joint_feedback}\n"
+        elif self.type_ == ArmMsgType.PiperMsgGripperFeedBack:
+            return f"Type: {self.type_}\n" f"Gripper Feed: {self.gripper_feedback}\n"
+        elif self.type_ == ArmMsgType.PiperMsgEndPoseFeedback_1:
+            return f"Type: {self.type_}\n" f"End Pose Feed: {self.arm_end_pose}\n"
+        elif self.type_ == ArmMsgType.PiperMsgEndPoseFeedback_2:
+            return f"Type: {self.type_}\n" f"End Pose Feed: {self.arm_end_pose}\n"
+        elif self.type_ == ArmMsgType.PiperMsgEndPoseFeedback_3:
+            return f"Type: {self.type_}\n" f"End Pose Feed: {self.arm_end_pose}\n"
+        elif self.type_ == ArmMsgType.PiperMsgHighSpdFeed_1:
+            return (
+                f"Type: {self.type_}\n"
+                f"High Spd Feedback: {self.arm_high_spd_feedback_1}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgHighSpdFeed_2:
+            return (
+                f"Type: {self.type_}\n"
+                f"High Spd Feedback: {self.arm_high_spd_feedback_2}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgHighSpdFeed_3:
+            return (
+                f"Type: {self.type_}\n"
+                f"High Spd Feedback: {self.arm_high_spd_feedback_3}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgHighSpdFeed_4:
+            return (
+                f"Type: {self.type_}\n"
+                f"High Spd Feedback: {self.arm_high_spd_feedback_4}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgHighSpdFeed_5:
+            return (
+                f"Type: {self.type_}\n"
+                f"High Spd Feedback: {self.arm_high_spd_feedback_5}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgHighSpdFeed_6:
+            return (
+                f"Type: {self.type_}\n"
+                f"High Spd Feedback: {self.arm_high_spd_feedback_6}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgLowSpdFeed_1:
+            return (
+                f"Type: {self.type_}\n"
+                f"Low Spd Feedback: {self.arm_low_spd_feedback_1}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgLowSpdFeed_2:
+            return (
+                f"Type: {self.type_}\n"
+                f"Low Spd Feedback: {self.arm_low_spd_feedback_2}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgLowSpdFeed_3:
+            return (
+                f"Type: {self.type_}\n"
+                f"Low Spd Feedback: {self.arm_low_spd_feedback_3}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgLowSpdFeed_4:
+            return (
+                f"Type: {self.type_}\n"
+                f"Low Spd Feedback: {self.arm_low_spd_feedback_4}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgLowSpdFeed_5:
+            return (
+                f"Type: {self.type_}\n"
+                f"Low Spd Feedback: {self.arm_low_spd_feedback_5}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgLowSpdFeed_6:
+            return (
+                f"Type: {self.type_}\n"
+                f"Low Spd Feedback: {self.arm_low_spd_feedback_6}\n"
+            )
         # 发送
-        elif(self.type_ == ArmMsgType.PiperMsgMotionCtrl_1):
-            return (f"Type: {self.type_}\n"f"PiperMsgMotionCtrl_1: {self.arm_motion_ctrl_1}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgMotionCtrl_2):
-            return (f"Type: {self.type_}\n"f"PiperMsgMotionCtrl_2: {self.arm_motion_ctrl_2}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgMotionCtrlCartesian_1):
-            return (f"Type: {self.type_}\n"f"ArmMsgMotionCtrlCartesian: {self.arm_motion_ctrl_cartesian}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgMotionCtrlCartesian_2):
-            return (f"Type: {self.type_}\n"f"ArmMsgMotionCtrlCartesian: {self.arm_motion_ctrl_cartesian}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgMotionCtrlCartesian_3):
-            return (f"Type: {self.type_}\n"f"ArmMsgMotionCtrlCartesian: {self.arm_motion_ctrl_cartesian}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgJointCtrl_12):
-            return (f"Type: {self.type_}\n"f"ArmMsgJointCtrl: {self.arm_joint_ctrl}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgJointCtrl_34):
-            return (f"Type: {self.type_}\n"f"ArmMsgJointCtrl: {self.arm_joint_ctrl}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgJointCtrl_56):
-            return (f"Type: {self.type_}\n"f"ArmMsgJointCtrl: {self.arm_joint_ctrl}\n")
-        elif(self.type_ == ArmMsgType.PiperMsgGripperCtrl):
-            return (f"Type: {self.type_}\n"f"PiperMsgGripperCtrl: {self.arm_gripper_ctrl}\n")
+        elif self.type_ == ArmMsgType.PiperMsgMotionCtrl_1:
+            return (
+                f"Type: {self.type_}\n"
+                f"PiperMsgMotionCtrl_1: {self.arm_motion_ctrl_1}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgMotionCtrl_2:
+            return (
+                f"Type: {self.type_}\n"
+                f"PiperMsgMotionCtrl_2: {self.arm_motion_ctrl_2}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgMotionCtrlCartesian_1:
+            return (
+                f"Type: {self.type_}\n"
+                f"ArmMsgMotionCtrlCartesian: {self.arm_motion_ctrl_cartesian}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgMotionCtrlCartesian_2:
+            return (
+                f"Type: {self.type_}\n"
+                f"ArmMsgMotionCtrlCartesian: {self.arm_motion_ctrl_cartesian}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgMotionCtrlCartesian_3:
+            return (
+                f"Type: {self.type_}\n"
+                f"ArmMsgMotionCtrlCartesian: {self.arm_motion_ctrl_cartesian}\n"
+            )
+        elif self.type_ == ArmMsgType.PiperMsgJointCtrl_12:
+            return f"Type: {self.type_}\n" f"ArmMsgJointCtrl: {self.arm_joint_ctrl}\n"
+        elif self.type_ == ArmMsgType.PiperMsgJointCtrl_34:
+            return f"Type: {self.type_}\n" f"ArmMsgJointCtrl: {self.arm_joint_ctrl}\n"
+        elif self.type_ == ArmMsgType.PiperMsgJointCtrl_56:
+            return f"Type: {self.type_}\n" f"ArmMsgJointCtrl: {self.arm_joint_ctrl}\n"
+        elif self.type_ == ArmMsgType.PiperMsgGripperCtrl:
+            return (
+                f"Type: {self.type_}\n"
+                f"PiperMsgGripperCtrl: {self.arm_gripper_ctrl}\n"
+            )
         else:
-            return (f"Type: {self.type_}\n")
+            return f"Type: {self.type_}\n"
 
     def __repr__(self):
         return self.__str__()

--- a/piper_msgs/msg_v1/arm_messages.py
+++ b/piper_msgs/msg_v1/arm_messages.py
@@ -1,15 +1,6 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
-from abc import ABC, abstractmethod
-import time
-from enum import Enum, auto
-import can
-from can.message import Message
-
-from typing import (
-    Optional,
-)
 from .arm_msg_type import ArmMsgType
 from .feedback.arm_end_pose import ArmMsgEndPoseFeedBack
 from .feedback.arm_joint_feedback import ArmMsgJointFeedBack
@@ -20,15 +11,9 @@ from .feedback.arm_feedback_current_end_vel_acc_param import (
 )
 from .feedback.arm_feedback_current_motor_angle_limit_max_spd import (
     ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd,
-    ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd,
 )
 from .feedback.arm_feedback_current_motor_max_acc_limit import (
     ArmMsgFeedbackCurrentMotorMaxAccLimit,
-    ArmMsgFeedbackAllCurrentMotorMaxAccLimit,
-)
-from .feedback.arm_feedback_joint_vel_acc import (
-    ArmMsgFeedbackJointVelAcc,
-    ArmMsgFeedbackAllJointVelAcc,
 )
 from .feedback.arm_high_spd_feedback import ArmHighSpdFeedback
 from .feedback.arm_low_spd_feedback import ArmLowSpdFeedback

--- a/piper_msgs/msg_v1/arm_msg_type.py
+++ b/piper_msgs/msg_v1/arm_msg_type.py
@@ -3,20 +3,22 @@
 
 from enum import Enum, auto
 
+
 class ArmMsgType(Enum):
-    '''
+    """
     机械臂消息类型,枚举类型
-    '''
+    """
+
     # 接收
-    PiperMsgUnkonwn = 0x00             #未知类型
-    PiperMsgStatusFeedback = auto()    #机械臂状态消息反馈
-    PiperMsgEndPoseFeedback_1 = auto() #机械臂末端位姿反馈1
-    PiperMsgEndPoseFeedback_2 = auto() #机械臂末端位姿反馈2
-    PiperMsgEndPoseFeedback_3 = auto() #机械臂末端位姿反馈3
-    PiperMsgJointFeedBack_12 = auto()  #机械臂臂部关节反馈12
-    PiperMsgJointFeedBack_34 = auto()  #机械臂臂部关节反馈34
-    PiperMsgJointFeedBack_56 = auto()  #机械臂臂部关节反馈56
-    PiperMsgGripperFeedBack = auto()  #夹爪反馈指令
+    PiperMsgUnkonwn = 0x00  # 未知类型
+    PiperMsgStatusFeedback = auto()  # 机械臂状态消息反馈
+    PiperMsgEndPoseFeedback_1 = auto()  # 机械臂末端位姿反馈1
+    PiperMsgEndPoseFeedback_2 = auto()  # 机械臂末端位姿反馈2
+    PiperMsgEndPoseFeedback_3 = auto()  # 机械臂末端位姿反馈3
+    PiperMsgJointFeedBack_12 = auto()  # 机械臂臂部关节反馈12
+    PiperMsgJointFeedBack_34 = auto()  # 机械臂臂部关节反馈34
+    PiperMsgJointFeedBack_56 = auto()  # 机械臂臂部关节反馈56
+    PiperMsgGripperFeedBack = auto()  # 夹爪反馈指令
     PiperMsgHighSpdFeed_1 = auto()
     PiperMsgHighSpdFeed_2 = auto()
     PiperMsgHighSpdFeed_3 = auto()
@@ -30,11 +32,11 @@ class ArmMsgType(Enum):
     PiperMsgLowSpdFeed_5 = auto()
     PiperMsgLowSpdFeed_6 = auto()
     # 发送
-    PiperMsgMotionCtrl_1=auto()
+    PiperMsgMotionCtrl_1 = auto()
     # PiperMsgStopCtrl = auto()
     # PiperMsgTrackCtrl = auto()
     # PiperMsgGragTeachCtrl = auto()
-    PiperMsgMotionCtrl_2=auto()
+    PiperMsgMotionCtrl_2 = auto()
     # PiperMsgModeCtrl = auto()
     # PiperMsgMoveModeCtrl = auto()
     # PiperMsgMoveSpdRateCtrl = auto()
@@ -44,37 +46,39 @@ class ArmMsgType(Enum):
     PiperMsgJointCtrl_12 = auto()
     PiperMsgJointCtrl_34 = auto()
     PiperMsgJointCtrl_56 = auto()
-    PiperMsgCircularPatternCoordNumUpdateCtrl=auto()
+    PiperMsgCircularPatternCoordNumUpdateCtrl = auto()
     PiperMsgGripperCtrl = auto()
     PiperMsgMasterSlaveModeConfig = auto()
     # PiperMsgMSLinkageConfig = auto()
     # PiperMsgMSFeedbackInstructionOffsetConfig=auto()
     # PiperMsgMSCtrlInstructionOffsetConfig=auto()
     # PiperMsgMSLinkageCtrlOffsetConfig=auto()
-    PiperMsgMotorEnableDisableConfig=auto() # 电机使能/失能设置指令
+    PiperMsgMotorEnableDisableConfig = auto()  # 电机使能/失能设置指令
     # PiperMsgMotorDisableConfig=auto()
     # PiperMsgSearchMotorAngleConfig=auto()
-    PiperMsgSearchMotorMaxAngleSpdAccLimit=auto()
+    PiperMsgSearchMotorMaxAngleSpdAccLimit = auto()
     # PiperMsgSearchMotorMaxAccConfig=auto()
-    PiperMsgFeedbackCurrentMotorAngleLimitMaxSpd=auto()
-    PiperMsgMotorAngleLimitMaxSpdSet=auto()#电机角度限制/最大速度设置指令
-    PiperMsgJointConfig=auto()
-    PiperMsgInstructionResponseConfig=auto()
-    PiperMsgParamEnquiryAndConfig=auto()
-    PiperMsgFeedbackCurrentEndVelAccParam=auto()
-    PiperMsgEndVelAccParamConfig=auto()
-    PiperMsgCrashProtectionRatingConfig=auto()
-    PiperMsgCrashProtectionRatingFeedback=auto()
-    PiperMsgFeedbackCurrentMotorMaxAccLimit=auto()
-    PiperMsgFeedbackJointVelAcc_1=auto()
-    PiperMsgFeedbackJointVelAcc_2=auto()
-    PiperMsgFeedbackJointVelAcc_3=auto()
-    PiperMsgFeedbackJointVelAcc_4=auto()
-    PiperMsgFeedbackJointVelAcc_5=auto()
-    PiperMsgFeedbackJointVelAcc_6=auto()
-    PiperMsgLightCtrl=auto()
-    PiperMsgCanUpdateSilentModeConfig=auto()
+    PiperMsgFeedbackCurrentMotorAngleLimitMaxSpd = auto()
+    PiperMsgMotorAngleLimitMaxSpdSet = auto()  # 电机角度限制/最大速度设置指令
+    PiperMsgJointConfig = auto()
+    PiperMsgInstructionResponseConfig = auto()
+    PiperMsgParamEnquiryAndConfig = auto()
+    PiperMsgFeedbackCurrentEndVelAccParam = auto()
+    PiperMsgEndVelAccParamConfig = auto()
+    PiperMsgCrashProtectionRatingConfig = auto()
+    PiperMsgCrashProtectionRatingFeedback = auto()
+    PiperMsgFeedbackCurrentMotorMaxAccLimit = auto()
+    PiperMsgFeedbackJointVelAcc_1 = auto()
+    PiperMsgFeedbackJointVelAcc_2 = auto()
+    PiperMsgFeedbackJointVelAcc_3 = auto()
+    PiperMsgFeedbackJointVelAcc_4 = auto()
+    PiperMsgFeedbackJointVelAcc_5 = auto()
+    PiperMsgFeedbackJointVelAcc_6 = auto()
+    PiperMsgLightCtrl = auto()
+    PiperMsgCanUpdateSilentModeConfig = auto()
+
     def __str__(self):
         return f"{self.name} (0x{self.value:X})"
+
     def __repr__(self):
         return f"{self.name}: 0x{self.value:X}"

--- a/piper_msgs/msg_v1/can_id.py
+++ b/piper_msgs/msg_v1/can_id.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
-from enum import Enum, auto
+from enum import Enum
 
 
 class CanIDPiper(Enum):

--- a/piper_msgs/msg_v1/can_id.py
+++ b/piper_msgs/msg_v1/can_id.py
@@ -3,19 +3,21 @@
 
 from enum import Enum, auto
 
+
 class CanIDPiper(Enum):
-    '''
+    """
     机械臂can id
-    '''
+    """
+
     # 主动反馈指令，可设置整体偏移为 0x2B1~0x2B8或 0x2C1~0x2C8，详见指令0x470
-    ARM_STATUS_FEEDBACK = 0x2A1         #机械臂状态反馈ID
-    ARM_END_POSE_FEEDBACK_1 = 0x2A2     #机械臂末端姿态反馈
+    ARM_STATUS_FEEDBACK = 0x2A1  # 机械臂状态反馈ID
+    ARM_END_POSE_FEEDBACK_1 = 0x2A2  # 机械臂末端姿态反馈
     ARM_END_POSE_FEEDBACK_2 = 0x2A3
     ARM_END_POSE_FEEDBACK_3 = 0x2A4
-    ARM_JOINT_FEEDBACK_12 = 0x2A5       #机械臂关节反馈
+    ARM_JOINT_FEEDBACK_12 = 0x2A5  # 机械臂关节反馈
     ARM_JOINT_FEEDBACK_34 = 0x2A6
     ARM_JOINT_FEEDBACK_56 = 0x2A7
-    ARM_GRIPPER_FEEDBACK = 0x2A8        #机械臂夹爪反馈
+    ARM_GRIPPER_FEEDBACK = 0x2A8  # 机械臂夹爪反馈
     # 运动控制指令，可设置整体偏移为 0x160~0x169或 0x170~0x179，详见指令0x470
     ARM_MOTION_CTRL_1 = 0x150
     # ARM_STOP_CTRL = 0x150               #机械臂快速急停
@@ -25,14 +27,14 @@ class CanIDPiper(Enum):
     # ARM_MODE_CTRL = 0x151               #机械臂控制模式
     # ARM_MOVE_MODE_CTRL = 0x151          #机械臂Mode模式
     # ARM_MOVE_SPD_RATE_CTRL = 0x151      #机械臂运动速度百分比
-    ARM_MOTION_CTRL_CARTESIAN_1=0x152#机械臂运动控制直角坐标系指令1,X&Y
-    ARM_MOTION_CTRL_CARTESIAN_2=0x153#机械臂运动控制直角坐标系指令1,Z&RX
-    ARM_MOTION_CTRL_CARTESIAN_3=0x154#机械臂运动控制直角坐标系指令1,RY&RZ
-    ARM_JOINT_CTRL_12=0x155             #机械臂臂部关节控制指令12,J1&J2
-    ARM_JOINT_CTRL_34=0x156             #机械臂臂部关节控制指令12,J3&J4
-    ARM_JOINT_CTRL_56=0x157             #机械臂臂部关节控制指令12,J5&J6
-    ARM_CIRCULAR_PATTERN_COORD_NUM_UPDATE_CTRL=0x158#圆弧模式坐标序号更新指令数据
-    ARM_GRIPPER_CTRL = 0x159            #夹爪控制指令
+    ARM_MOTION_CTRL_CARTESIAN_1 = 0x152  # 机械臂运动控制直角坐标系指令1,X&Y
+    ARM_MOTION_CTRL_CARTESIAN_2 = 0x153  # 机械臂运动控制直角坐标系指令1,Z&RX
+    ARM_MOTION_CTRL_CARTESIAN_3 = 0x154  # 机械臂运动控制直角坐标系指令1,RY&RZ
+    ARM_JOINT_CTRL_12 = 0x155  # 机械臂臂部关节控制指令12,J1&J2
+    ARM_JOINT_CTRL_34 = 0x156  # 机械臂臂部关节控制指令12,J3&J4
+    ARM_JOINT_CTRL_56 = 0x157  # 机械臂臂部关节控制指令12,J5&J6
+    ARM_CIRCULAR_PATTERN_COORD_NUM_UPDATE_CTRL = 0x158  # 圆弧模式坐标序号更新指令数据
+    ARM_GRIPPER_CTRL = 0x159  # 夹爪控制指令
     # 机械臂参数配置与设定指令
     # 若指令名称带有反馈、应答; 决策控制单元->机械臂主控
     # 若指令名称带有查询、设置; 机械臂主控->决策控制单元
@@ -43,46 +45,50 @@ class CanIDPiper(Enum):
     # ARM_MS_LINKAGE_CTRL_OFFSET_CONFIG = 0x470#随动主从模式设置指令-联动模式控制目标地址偏移值
     # 设置为示教输入臂后，主动周期反馈报文 ID 增加偏移（偏移量可设置），模式切换为联动示教输入模式，不响应控制指令，且会主动发送关节模式控制指令；
     # 设置为运动输出臂后恢复为常规状态（退出联动示教输入模式，进入待机模式）；未收到此条指令的机械臂默认为此状态
-    ARM_MOTOR_ENABLE_DISABLE_CONFIG = 0x471     #电机使能指令
+    ARM_MOTOR_ENABLE_DISABLE_CONFIG = 0x471  # 电机使能指令
     # ARM_MOTOR_DISABLE_CONFIG = 0x471    #电机失能指令
     # ARM_SEARCH_MOTOR_ANGLE_CONFIG = 0x472 #查询电机角度
-    ARM_SEARCH_MOTOR_MAX_SPD_ACC_LIMIT = 0x472 #查询电机角度/最大速度/加速度限制
+    ARM_SEARCH_MOTOR_MAX_SPD_ACC_LIMIT = 0x472  # 查询电机角度/最大速度/加速度限制
     # ARM_SEARCH_MOTOR_MAX_ACC_CONFIG = 0x472 #查询电机最大加速度限制
-    ARM_FEEDBACK_CURRENT_MOTOR_ANGLE_LIMIT_MAX_SPD = 0x473 #反馈当前电机最大角度限制,最小角度限制,最大关节速度
-    ARM_MOTOR_ANGLE_LIMIT_MAX_SPD_SET = 0x474      #电机角度限制/最大速度设置指令
-    ARM_JOINT_CONFIG = 0x475            #关节设置指令
-    ARM_INSTRUCTION_RESPONSE_CONFIG=0x476#设置指令应答
-    ARM_PARAM_ENQUIRY_AND_CONFIG = 0x477#机械臂参数查询与设置指令
-    ARM_FEEDBACK_CURRENT_END_VEL_ACC_PARAM = 0x478    #反馈当前末端速度/加速度参数
-    ARM_END_VEL_ACC_PARAM_CONFIG = 0x479      #末端速度/加速度参数设置指令
-    ARM_CRASH_PROTECTION_RATING_CONFIG=0x47A#碰撞防护等级设置指令
-    ARM_CRASH_PROTECTION_RATING_FEEDBACK=0x47B#碰撞防护等级反馈指令
-    ARM_FEEDBACK_CURRENT_MOTOR_MAX_ACC_LIMIT=0x47C#反馈当前电机最大加速度限制
-    ARM_FEEDBACK_JOINT_VEL_ACC_1 = 0x481         #反馈当前关节的末端速度/加速度
+    ARM_FEEDBACK_CURRENT_MOTOR_ANGLE_LIMIT_MAX_SPD = (
+        0x473  # 反馈当前电机最大角度限制,最小角度限制,最大关节速度
+    )
+    ARM_MOTOR_ANGLE_LIMIT_MAX_SPD_SET = 0x474  # 电机角度限制/最大速度设置指令
+    ARM_JOINT_CONFIG = 0x475  # 关节设置指令
+    ARM_INSTRUCTION_RESPONSE_CONFIG = 0x476  # 设置指令应答
+    ARM_PARAM_ENQUIRY_AND_CONFIG = 0x477  # 机械臂参数查询与设置指令
+    ARM_FEEDBACK_CURRENT_END_VEL_ACC_PARAM = 0x478  # 反馈当前末端速度/加速度参数
+    ARM_END_VEL_ACC_PARAM_CONFIG = 0x479  # 末端速度/加速度参数设置指令
+    ARM_CRASH_PROTECTION_RATING_CONFIG = 0x47A  # 碰撞防护等级设置指令
+    ARM_CRASH_PROTECTION_RATING_FEEDBACK = 0x47B  # 碰撞防护等级反馈指令
+    ARM_FEEDBACK_CURRENT_MOTOR_MAX_ACC_LIMIT = 0x47C  # 反馈当前电机最大加速度限制
+    ARM_FEEDBACK_JOINT_VEL_ACC_1 = 0x481  # 反馈当前关节的末端速度/加速度
     ARM_FEEDBACK_JOINT_VEL_ACC_2 = 0x482
     ARM_FEEDBACK_JOINT_VEL_ACC_3 = 0x483
     ARM_FEEDBACK_JOINT_VEL_ACC_4 = 0x484
     ARM_FEEDBACK_JOINT_VEL_ACC_5 = 0x485
     ARM_FEEDBACK_JOINT_VEL_ACC_6 = 0x486
-    #灯光控制0x1节点ID，帧ID 0x121
-    ARM_LIGHT_CTRL = 0x121              #灯光控制指令
-    #驱动器信息高速反馈，节点ID 0x1~0x6
+    # 灯光控制0x1节点ID，帧ID 0x121
+    ARM_LIGHT_CTRL = 0x121  # 灯光控制指令
+    # 驱动器信息高速反馈，节点ID 0x1~0x6
     ARM_INFO_HIGH_SPD_FEEDBACK_1 = 0x251
     ARM_INFO_HIGH_SPD_FEEDBACK_2 = 0x252
     ARM_INFO_HIGH_SPD_FEEDBACK_3 = 0x253
     ARM_INFO_HIGH_SPD_FEEDBACK_4 = 0x254
     ARM_INFO_HIGH_SPD_FEEDBACK_5 = 0x255
     ARM_INFO_HIGH_SPD_FEEDBACK_6 = 0x256
-    #驱动器信息低速反馈，节点ID 0x1~0x6
+    # 驱动器信息低速反馈，节点ID 0x1~0x6
     ARM_INFO_LOW_SPD_FEEDBACK_1 = 0x261
     ARM_INFO_LOW_SPD_FEEDBACK_2 = 0x262
     ARM_INFO_LOW_SPD_FEEDBACK_3 = 0x263
     ARM_INFO_LOW_SPD_FEEDBACK_4 = 0x264
     ARM_INFO_LOW_SPD_FEEDBACK_5 = 0x265
     ARM_INFO_LOW_SPD_FEEDBACK_6 = 0x266
-    #CAN 升级总线静默模式设定指令
-    ARM_CAN_UPDATE_SILENT_MODE_CONFIG=0x422
+    # CAN 升级总线静默模式设定指令
+    ARM_CAN_UPDATE_SILENT_MODE_CONFIG = 0x422
+
     def __str__(self):
         return f"{self.name} (0x{self.value:X})"
+
     def __repr__(self):
         return f"{self.name}: 0x{self.value:X}"

--- a/piper_msgs/msg_v1/feedback/arm_crash_protection_rating_feedback.py
+++ b/piper_msgs/msg_v1/feedback/arm_crash_protection_rating_feedback.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
+
 class ArmMsgCrashProtectionRatingFeedback:
-    '''
+    """
     末端速度/加速度参数反馈指令
-    
+
     0x47B
 
     当前设定值 : 0~8
@@ -19,15 +20,17 @@ class ArmMsgCrashProtectionRatingFeedback:
     :Byte 5: 6 号关节碰撞防护等级, uint8
     :Byte 6: 保留
     :Byte 7: 保留
-    '''
-    def __init__(self, 
-                 jonit_1_protection_level:int=0, 
-                 jonit_2_protection_level:int=0, 
-                 jonit_3_protection_level: int=0,
-                 jonit_4_protection_level: int=0,
-                 jonit_5_protection_level: int=0,
-                 jonit_6_protection_level: int=0
-                 ):
+    """
+
+    def __init__(
+        self,
+        jonit_1_protection_level: int = 0,
+        jonit_2_protection_level: int = 0,
+        jonit_3_protection_level: int = 0,
+        jonit_4_protection_level: int = 0,
+        jonit_5_protection_level: int = 0,
+        jonit_6_protection_level: int = 0,
+    ):
         """
         初始化 ArmMsgCrashProtectionRatingFeedback 实例。
         """
@@ -42,14 +45,16 @@ class ArmMsgCrashProtectionRatingFeedback:
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"ArmMsgCrashProtectionRatingFeedback(\n"
-                f"  jonit_1_protection_level: {self.jonit_1_protection_level},\n"
-                f"  jonit_2_protection_level: {self.jonit_2_protection_level},\n"
-                f"  jonit_3_protection_level: {self.jonit_3_protection_level},\n"
-                f"  jonit_4_protection_level: {self.jonit_4_protection_level},\n"
-                f"  jonit_5_protection_level: {self.jonit_5_protection_level},\n"
-                f"  jonit_6_protection_level: {self.jonit_6_protection_level}\n"
-                f")")
+        return (
+            f"ArmMsgCrashProtectionRatingFeedback(\n"
+            f"  jonit_1_protection_level: {self.jonit_1_protection_level},\n"
+            f"  jonit_2_protection_level: {self.jonit_2_protection_level},\n"
+            f"  jonit_3_protection_level: {self.jonit_3_protection_level},\n"
+            f"  jonit_4_protection_level: {self.jonit_4_protection_level},\n"
+            f"  jonit_5_protection_level: {self.jonit_5_protection_level},\n"
+            f"  jonit_6_protection_level: {self.jonit_6_protection_level}\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/feedback/arm_end_pose.py
+++ b/piper_msgs/msg_v1/feedback/arm_end_pose.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
-class ArmMsgEndPoseFeedBack():
-    '''
+
+class ArmMsgEndPoseFeedBack:
+    """
     机械臂末端姿态反馈
-    '''
-    def __init__(self, X_axis: int=0, Y_axis: int=0, 
-                 Z_axis: int=0, RX_axis: int=0, 
-                 RY_axis: int=0, RZ_axis: int=0):
+    """
+
+    def __init__(
+        self,
+        X_axis: int = 0,
+        Y_axis: int = 0,
+        Z_axis: int = 0,
+        RX_axis: int = 0,
+        RY_axis: int = 0,
+        RZ_axis: int = 0,
+    ):
         self.X_axis = X_axis
         self.Y_axis = Y_axis
         self.Z_axis = Z_axis
@@ -23,13 +31,15 @@ class ArmMsgEndPoseFeedBack():
             (" Z_axis ", self.Z_axis, self.Z_axis * 0.001),
             (" RX_axis ", self.RX_axis, self.RX_axis * 0.001),
             (" RY_axis ", self.RY_axis, self.RY_axis * 0.001),
-            (" RZ_axis ", self.RZ_axis, self.RZ_axis * 0.001)
+            (" RZ_axis ", self.RZ_axis, self.RZ_axis * 0.001),
         ]
 
         # 生成格式化字符串，保留三位小数
-        formatted_ = "\n".join([f"{name}: {pose}, {pose_f:.3f}" for name, pose, pose_f in end_pose])
-        
+        formatted_ = "\n".join(
+            [f"{name}: {pose}, {pose_f:.3f}" for name, pose, pose_f in end_pose]
+        )
+
         return f"ArmMsgEndPoseFeedBack:\n{formatted_}"
-    
+
     def __repr__(self):
         return self.__str__()

--- a/piper_msgs/msg_v1/feedback/arm_feedback_current_end_vel_acc_param.py
+++ b/piper_msgs/msg_v1/feedback/arm_feedback_current_end_vel_acc_param.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 import math
+
+
 class ArmMsgFeedbackCurrentEndVelAccParam:
-    '''
+    """
     反馈当前末端速度/加速度参数
 
     0x478
@@ -15,13 +17,15 @@ class ArmMsgFeedbackCurrentEndVelAccParam:
     :Byte 5: 末端最大线加速度 L
     :Byte 6: 末端最大角加速度 H, uint16, 单位 0.001rad/s^2
     :Byte 7: 末端最大角加速度 L
-    '''
-    def __init__(self, 
-                 end_max_linear_vel:int=0, 
-                 end_max_angular_vel:int=0, 
-                 end_max_linear_acc: int=0,
-                 end_max_angular_acc: int=0
-                 ):
+    """
+
+    def __init__(
+        self,
+        end_max_linear_vel: int = 0,
+        end_max_angular_vel: int = 0,
+        end_max_linear_acc: int = 0,
+        end_max_angular_acc: int = 0,
+    ):
         """
         初始化 ArmMsgFeedbackCurrentEndVelAccParam 实例。
         """
@@ -34,12 +38,14 @@ class ArmMsgFeedbackCurrentEndVelAccParam:
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"ArmMsgFeedbackCurrentEndVelAccParam(\n"
-                f"  end_max_linear_vel: {self.end_max_linear_vel}, {self.end_max_linear_vel*0.001:.3f}m/s\n"
-                f"  end_max_angular_vel: {self.end_max_angular_vel}, {self.end_max_angular_vel*0.001:.3f}rad/s,\n"
-                f"  end_max_linear_acc: {self.end_max_linear_acc }, {self.end_max_linear_acc*0.001:.3f}m/s^2,\n"
-                f"  end_max_angular_acc: {self.end_max_angular_acc}, {self.end_max_angular_acc*0.001:.3f}rad/s^2\n"
-                f")")
+        return (
+            f"ArmMsgFeedbackCurrentEndVelAccParam(\n"
+            f"  end_max_linear_vel: {self.end_max_linear_vel}, {self.end_max_linear_vel*0.001:.3f}m/s\n"
+            f"  end_max_angular_vel: {self.end_max_angular_vel}, {self.end_max_angular_vel*0.001:.3f}rad/s,\n"
+            f"  end_max_linear_acc: {self.end_max_linear_acc }, {self.end_max_linear_acc*0.001:.3f}m/s^2,\n"
+            f"  end_max_angular_acc: {self.end_max_angular_acc}, {self.end_max_angular_acc*0.001:.3f}rad/s^2\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/feedback/arm_feedback_current_motor_angle_limit_max_spd.py
+++ b/piper_msgs/msg_v1/feedback/arm_feedback_current_motor_angle_limit_max_spd.py
@@ -3,15 +3,20 @@
 from typing_extensions import (
     Literal,
 )
+
+
 class ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd:
-    '''
+    """
     反馈当前电机限制角度/最大速度
-    '''
-    def __init__(self, 
-                 motor_num:Literal[0, 1, 2, 3, 4, 5, 6]=0, 
-                 max_angle_limit: int=0, 
-                 min_angle_limit: int=0,
-                 max_jonit_spd: int=0):
+    """
+
+    def __init__(
+        self,
+        motor_num: Literal[0, 1, 2, 3, 4, 5, 6] = 0,
+        max_angle_limit: int = 0,
+        min_angle_limit: int = 0,
+        max_jonit_spd: int = 0,
+    ):
         """
         初始化 ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd 实例。
 
@@ -35,12 +40,14 @@ class ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd:
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(\n"
-                f"  motor_num: {self.motor_num},\n"
-                f"  max_angle_limit: {self.max_angle_limit}, {self.max_angle_limit * 0.1:.1f},\n"
-                f"  min_angle_limit: {self.min_angle_limit}, {self.min_angle_limit * 0.1:.1f},\n"
-                f"  max_jonit_spd: {self.max_jonit_spd}, {self.max_jonit_spd * 0.001:.3f}\n"
-                f")")
+        return (
+            f"ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(\n"
+            f"  motor_num: {self.motor_num},\n"
+            f"  max_angle_limit: {self.max_angle_limit}, {self.max_angle_limit * 0.1:.1f},\n"
+            f"  min_angle_limit: {self.min_angle_limit}, {self.min_angle_limit * 0.1:.1f},\n"
+            f"  max_jonit_spd: {self.max_jonit_spd}, {self.max_jonit_spd * 0.001:.3f}\n"
+            f")"
+        )
 
     def __repr__(self):
         """
@@ -50,17 +57,33 @@ class ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd:
         """
         return self.__str__()
 
+
 class ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd:
-    '''
+    """
     反馈当前电机限制角度/最大速度
-    '''
-    def __init__(self, 
-                 m1:ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(0,0,0,0),
-                 m2:ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(0,0,0,0),
-                 m3:ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(0,0,0,0),
-                 m4:ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(0,0,0,0),
-                 m5:ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(0,0,0,0),
-                 m6:ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(0,0,0,0)):
+    """
+
+    def __init__(
+        self,
+        m1: ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(
+            0, 0, 0, 0
+        ),
+        m2: ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(
+            0, 0, 0, 0
+        ),
+        m3: ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(
+            0, 0, 0, 0
+        ),
+        m4: ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(
+            0, 0, 0, 0
+        ),
+        m5: ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(
+            0, 0, 0, 0
+        ),
+        m6: ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(
+            0, 0, 0, 0
+        ),
+    ):
         """
         初始化 ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd 实例。
 
@@ -73,26 +96,36 @@ class ArmMsgFeedbackAllCurrentMotorAngleLimitMaxSpd:
         :Byte 6: 最大关节速度
         :Byte 7:
         """
-        self.__m = [ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(0,0,0,0), m1, m2, m3, m4, m5, m6]
+        self.__m = [
+            ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(0, 0, 0, 0),
+            m1,
+            m2,
+            m3,
+            m4,
+            m5,
+            m6,
+        ]
         self.motor = [ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd() for _ in range(7)]
-        self.motor[0] = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(0,0,0,0)
-    
+        self.motor[0] = ArmMsgFeedbackCurrentMotorAngleLimitMaxSpd(0, 0, 0, 0)
+
     def assign(self):
-        for i in range(1,7):
-            if(self.__m[i].motor_num != 0):
+        for i in range(1, 7):
+            if self.__m[i].motor_num != 0:
                 self.motor[i] = self.__m[i]
 
     def __str__(self):
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"{self.motor[1]}\n"
-                f"{self.motor[2]}\n"
-                f"{self.motor[3]}\n"
-                f"{self.motor[4]}\n"
-                f"{self.motor[5]}\n"
-                f"{self.motor[6]}\n"
-                f")")
+        return (
+            f"{self.motor[1]}\n"
+            f"{self.motor[2]}\n"
+            f"{self.motor[3]}\n"
+            f"{self.motor[4]}\n"
+            f"{self.motor[5]}\n"
+            f"{self.motor[6]}\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/feedback/arm_feedback_current_motor_max_acc_limit.py
+++ b/piper_msgs/msg_v1/feedback/arm_feedback_current_motor_max_acc_limit.py
@@ -3,8 +3,10 @@
 from typing_extensions import (
     Literal,
 )
+
+
 class ArmMsgFeedbackCurrentMotorMaxAccLimit:
-    '''
+    """
     反馈当前电机最大加速度限制
 
     0x47C
@@ -13,16 +15,18 @@ class ArmMsgFeedbackCurrentMotorMaxAccLimit:
                              1-6 代表关节驱动器序号；
     :Byte 1: 最大关节加速度 H, uint16, 单位 RPM/s
     :Byte 2: 最大关节加速度 L
-    '''
-    def __init__(self, 
-                 joint_motor_num:Literal[0, 1, 2, 3, 4, 5, 6]=0, 
-                 max_joint_acc:int=0
-                 ):
+    """
+
+    def __init__(
+        self, joint_motor_num: Literal[0, 1, 2, 3, 4, 5, 6] = 0, max_joint_acc: int = 0
+    ):
         """
         初始化 ArmMsgFeedbackCurrentMotorMaxAccLimit 实例。
         """
         if joint_motor_num not in [0, 1, 2, 3, 4, 5, 6]:
-            raise ValueError(f"joint_motor_num 值 {joint_motor_num} 超出范围 [1, 2, 3, 4, 5, 6]")
+            raise ValueError(
+                f"joint_motor_num 值 {joint_motor_num} 超出范围 [1, 2, 3, 4, 5, 6]"
+            )
         self.joint_motor_num = joint_motor_num
         self.max_joint_acc = max_joint_acc
 
@@ -30,10 +34,12 @@ class ArmMsgFeedbackCurrentMotorMaxAccLimit:
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"ArmMsgFeedbackCurrentMotorMaxAccLimit(\n"
-                f"  joint_motor_num: {self.joint_motor_num},\n"
-                f"  max_joint_acc: {self.max_joint_acc}\n"
-                f")")
+        return (
+            f"ArmMsgFeedbackCurrentMotorMaxAccLimit(\n"
+            f"  joint_motor_num: {self.joint_motor_num},\n"
+            f"  max_joint_acc: {self.max_joint_acc}\n"
+            f")"
+        )
 
     def __repr__(self):
         """
@@ -43,8 +49,9 @@ class ArmMsgFeedbackCurrentMotorMaxAccLimit:
         """
         return self.__str__()
 
+
 class ArmMsgFeedbackAllCurrentMotorMaxAccLimit:
-    '''
+    """
     反馈当前电机最大加速度限制
 
     0x47C
@@ -53,37 +60,53 @@ class ArmMsgFeedbackAllCurrentMotorMaxAccLimit:
                              1-6 代表关节驱动器序号；
     :Byte 1: 最大关节加速度 H, uint16, 单位 RPM/s
     :Byte 2: 最大关节加速度 L
-    '''
-    def __init__(self, 
-                 m1:ArmMsgFeedbackCurrentMotorMaxAccLimit=ArmMsgFeedbackCurrentMotorMaxAccLimit(0,0), 
-                 m2:ArmMsgFeedbackCurrentMotorMaxAccLimit=ArmMsgFeedbackCurrentMotorMaxAccLimit(0,0),
-                 m3:ArmMsgFeedbackCurrentMotorMaxAccLimit=ArmMsgFeedbackCurrentMotorMaxAccLimit(0,0), 
-                 m4:ArmMsgFeedbackCurrentMotorMaxAccLimit=ArmMsgFeedbackCurrentMotorMaxAccLimit(0,0), 
-                 m5:ArmMsgFeedbackCurrentMotorMaxAccLimit=ArmMsgFeedbackCurrentMotorMaxAccLimit(0,0), 
-                 m6:ArmMsgFeedbackCurrentMotorMaxAccLimit=ArmMsgFeedbackCurrentMotorMaxAccLimit(0,0)
-                 ):
+    """
+
+    def __init__(
+        self,
+        m1: ArmMsgFeedbackCurrentMotorMaxAccLimit = ArmMsgFeedbackCurrentMotorMaxAccLimit(
+            0, 0
+        ),
+        m2: ArmMsgFeedbackCurrentMotorMaxAccLimit = ArmMsgFeedbackCurrentMotorMaxAccLimit(
+            0, 0
+        ),
+        m3: ArmMsgFeedbackCurrentMotorMaxAccLimit = ArmMsgFeedbackCurrentMotorMaxAccLimit(
+            0, 0
+        ),
+        m4: ArmMsgFeedbackCurrentMotorMaxAccLimit = ArmMsgFeedbackCurrentMotorMaxAccLimit(
+            0, 0
+        ),
+        m5: ArmMsgFeedbackCurrentMotorMaxAccLimit = ArmMsgFeedbackCurrentMotorMaxAccLimit(
+            0, 0
+        ),
+        m6: ArmMsgFeedbackCurrentMotorMaxAccLimit = ArmMsgFeedbackCurrentMotorMaxAccLimit(
+            0, 0
+        ),
+    ):
         """
         初始化 ArmMsgFeedbackAllCurrentMotorMaxAccLimit 实例。
         """
-        self.__m = [ArmMsgFeedbackCurrentMotorMaxAccLimit(0,0), m1, m2, m3, m4, m5, m6]
-        self.motor = [ArmMsgFeedbackCurrentMotorMaxAccLimit(0,0) for _ in range(7)]
+        self.__m = [ArmMsgFeedbackCurrentMotorMaxAccLimit(0, 0), m1, m2, m3, m4, m5, m6]
+        self.motor = [ArmMsgFeedbackCurrentMotorMaxAccLimit(0, 0) for _ in range(7)]
 
     def assign(self):
-        for i in range(1,7):
-            if(self.__m[i].joint_motor_num != 0):
+        for i in range(1, 7):
+            if self.__m[i].joint_motor_num != 0:
                 self.motor[i] = self.__m[i]
-    
+
     def __str__(self):
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"{self.motor[1]}\n"
-                f"{self.motor[2]}\n"
-                f"{self.motor[3]}\n"
-                f"{self.motor[4]}\n"
-                f"{self.motor[5]}\n"
-                f"{self.motor[6]}\n"
-                f")")
+        return (
+            f"{self.motor[1]}\n"
+            f"{self.motor[2]}\n"
+            f"{self.motor[3]}\n"
+            f"{self.motor[4]}\n"
+            f"{self.motor[5]}\n"
+            f"{self.motor[6]}\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/feedback/arm_feedback_joint_vel_acc.py
+++ b/piper_msgs/msg_v1/feedback/arm_feedback_joint_vel_acc.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
-import math
 from typing_extensions import (
     Literal,
 )

--- a/piper_msgs/msg_v1/feedback/arm_feedback_joint_vel_acc.py
+++ b/piper_msgs/msg_v1/feedback/arm_feedback_joint_vel_acc.py
@@ -4,8 +4,10 @@ import math
 from typing_extensions import (
     Literal,
 )
+
+
 class ArmMsgFeedbackJointVelAcc:
-    '''
+    """
     反馈各个关节当前末端速度/加速度
 
     0x481 ~ 0x486 代表 1~6 号关节
@@ -18,19 +20,23 @@ class ArmMsgFeedbackJointVelAcc:
     :Byte 5: 末端线加速度 L
     :Byte 6: 末端角加速度 H, uint16, 单位 0.001rad/s^2
     :Byte 7: 末端角加速度 L
-    '''
-    def __init__(self, 
-                 can_id:Literal[0,0x481,0x482,0x483,0x484,0x485,0x486]=0,
-                 end_linear_vel:int=0, 
-                 end_angular_vel:int=0, 
-                 end_linear_acc: int=0,
-                 end_angular_acc: int=0
-                 ):
+    """
+
+    def __init__(
+        self,
+        can_id: Literal[0, 0x481, 0x482, 0x483, 0x484, 0x485, 0x486] = 0,
+        end_linear_vel: int = 0,
+        end_angular_vel: int = 0,
+        end_linear_acc: int = 0,
+        end_angular_acc: int = 0,
+    ):
         """
         初始化 ArmMsgFeedbackJointVelAcc 实例。
         """
-        if can_id not in [0,0x481,0x482,0x483,0x484,0x485,0x486]:
-            raise ValueError(f"can_id 值 {can_id} 不在范围 [0x481,0x482,0x483,0x484,0x485,0x486]")
+        if can_id not in [0, 0x481, 0x482, 0x483, 0x484, 0x485, 0x486]:
+            raise ValueError(
+                f"can_id 值 {can_id} 不在范围 [0x481,0x482,0x483,0x484,0x485,0x486]"
+            )
         self.can_id = can_id
         self.end_linear_vel = end_linear_vel
         self.end_angular_vel = end_angular_vel
@@ -41,13 +47,15 @@ class ArmMsgFeedbackJointVelAcc:
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"ArmMsgFeedbackJointVelAcc(\n"
-                f"  can_id: {self.can_id},\n"
-                f"  end_linear_vel: {self.end_linear_vel},\n"
-                f"  end_angular_vel: {self.end_angular_vel },\n"
-                f"  end_linear_acc: {self.end_linear_acc },\n"
-                f"  end_angular_acc: {self.end_angular_acc}\n"
-                f")")
+        return (
+            f"ArmMsgFeedbackJointVelAcc(\n"
+            f"  can_id: {self.can_id},\n"
+            f"  end_linear_vel: {self.end_linear_vel},\n"
+            f"  end_angular_vel: {self.end_angular_vel },\n"
+            f"  end_linear_acc: {self.end_linear_acc },\n"
+            f"  end_angular_acc: {self.end_angular_acc}\n"
+            f")"
+        )
 
     def __repr__(self):
         """
@@ -57,8 +65,9 @@ class ArmMsgFeedbackJointVelAcc:
         """
         return self.__str__()
 
+
 class ArmMsgFeedbackAllJointVelAcc:
-    '''
+    """
     反馈各个关节当前末端速度/加速度,为全部关节的消息
 
     0x481 ~ 0x486 代表 1~6 号关节
@@ -71,37 +80,42 @@ class ArmMsgFeedbackAllJointVelAcc:
     :Byte 5: 末端线加速度 L
     :Byte 6: 末端角加速度 H, uint16, 单位 0.001rad/s^2
     :Byte 7: 末端角加速度 L
-    '''
-    def __init__(self, 
-                 j1:ArmMsgFeedbackJointVelAcc = ArmMsgFeedbackJointVelAcc(0,0,0,0,0),
-                 j2:ArmMsgFeedbackJointVelAcc = ArmMsgFeedbackJointVelAcc(0,0,0,0,0),
-                 j3:ArmMsgFeedbackJointVelAcc = ArmMsgFeedbackJointVelAcc(0,0,0,0,0),
-                 j4:ArmMsgFeedbackJointVelAcc = ArmMsgFeedbackJointVelAcc(0,0,0,0,0),
-                 j5:ArmMsgFeedbackJointVelAcc = ArmMsgFeedbackJointVelAcc(0,0,0,0,0),
-                 j6:ArmMsgFeedbackJointVelAcc = ArmMsgFeedbackJointVelAcc(0,0,0,0,0)):
+    """
+
+    def __init__(
+        self,
+        j1: ArmMsgFeedbackJointVelAcc = ArmMsgFeedbackJointVelAcc(0, 0, 0, 0, 0),
+        j2: ArmMsgFeedbackJointVelAcc = ArmMsgFeedbackJointVelAcc(0, 0, 0, 0, 0),
+        j3: ArmMsgFeedbackJointVelAcc = ArmMsgFeedbackJointVelAcc(0, 0, 0, 0, 0),
+        j4: ArmMsgFeedbackJointVelAcc = ArmMsgFeedbackJointVelAcc(0, 0, 0, 0, 0),
+        j5: ArmMsgFeedbackJointVelAcc = ArmMsgFeedbackJointVelAcc(0, 0, 0, 0, 0),
+        j6: ArmMsgFeedbackJointVelAcc = ArmMsgFeedbackJointVelAcc(0, 0, 0, 0, 0),
+    ):
         """
         初始化 ArmMsgFeedbackAllJointVelAcc 实例。
         """
-        self.j = [ArmMsgFeedbackJointVelAcc(0,0,0,0,0), j1, j2, j3, j4, j5, j6]
+        self.j = [ArmMsgFeedbackJointVelAcc(0, 0, 0, 0, 0), j1, j2, j3, j4, j5, j6]
         self.joint = [ArmMsgFeedbackJointVelAcc() for _ in range(7)]
-        self.joint[0] = ArmMsgFeedbackJointVelAcc(0,0,0,0,0)
-    
+        self.joint[0] = ArmMsgFeedbackJointVelAcc(0, 0, 0, 0, 0)
+
     def assign(self):
-        for i in range(1,7):
-            if(self.j[i].can_id != 0):
+        for i in range(1, 7):
+            if self.j[i].can_id != 0:
                 self.joint[i] = self.j[i]
-    
+
     def __str__(self):
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"{self.joint[1]}\n"
-                f"{self.joint[2]}\n"
-                f"{self.joint[3]}\n"
-                f"{self.joint[4]}\n"
-                f"{self.joint[5]}\n"
-                f"{self.joint[6]}\n"
-                f")")
+        return (
+            f"{self.joint[1]}\n"
+            f"{self.joint[2]}\n"
+            f"{self.joint[3]}\n"
+            f"{self.joint[4]}\n"
+            f"{self.joint[5]}\n"
+            f"{self.joint[6]}\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/feedback/arm_high_spd_feedback.py
+++ b/piper_msgs/msg_v1/feedback/arm_high_spd_feedback.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
-import math
 from typing_extensions import (
     Literal,
 )

--- a/piper_msgs/msg_v1/feedback/arm_high_spd_feedback.py
+++ b/piper_msgs/msg_v1/feedback/arm_high_spd_feedback.py
@@ -4,8 +4,10 @@ import math
 from typing_extensions import (
     Literal,
 )
+
+
 class ArmHighSpdFeedback:
-    '''
+    """
     驱动器信息高速反馈 0x5
 
     节点 ID: 0x1~0x06
@@ -19,18 +21,22 @@ class ArmHighSpdFeedback:
     :Byte 5: 位置次高位
     :Byte 6: 位置次低位
     :Byte 7: 位置最低位
-    '''
-    def __init__(self, 
-                 can_id:Literal[0x000,0x251,0x252,0x253,0x254,0x254,0x255,0x256]=0,
-                 motor_speed:int=0, 
-                 current:int=0, 
-                 pos: int=0,
-                 ):
+    """
+
+    def __init__(
+        self,
+        can_id: Literal[0x000, 0x251, 0x252, 0x253, 0x254, 0x254, 0x255, 0x256] = 0,
+        motor_speed: int = 0,
+        current: int = 0,
+        pos: int = 0,
+    ):
         """
         初始化 ArmHighSpdFeedback 实例。
         """
-        if can_id not in [0x000,0x251,0x252,0x253,0x254,0x254,0x255,0x256]:
-            raise ValueError(f"can_id 值 {can_id} 不在范围 [0x000,0x251,0x252,0x253,0x254,0x254,0x255,0x256]")
+        if can_id not in [0x000, 0x251, 0x252, 0x253, 0x254, 0x254, 0x255, 0x256]:
+            raise ValueError(
+                f"can_id 值 {can_id} 不在范围 [0x000,0x251,0x252,0x253,0x254,0x254,0x255,0x256]"
+            )
         self.can_id = can_id
         self.motor_speed = motor_speed
         self.current = current
@@ -40,12 +46,14 @@ class ArmHighSpdFeedback:
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"ArmHighSpdFeedback(\n"
-                f"  can_id: {hex(self.can_id)},\n"
-                f"  motor_speed: {self.motor_speed} RPM,\n"
-                f"  current: {self.current}, {self.current*0.1}A\n"
-                f"  pos: {self.pos} rad\n"
-                f")")
+        return (
+            f"ArmHighSpdFeedback(\n"
+            f"  can_id: {hex(self.can_id)},\n"
+            f"  motor_speed: {self.motor_speed} RPM,\n"
+            f"  current: {self.current}, {self.current*0.1}A\n"
+            f"  pos: {self.pos} rad\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/feedback/arm_joint_feedback.py
+++ b/piper_msgs/msg_v1/feedback/arm_joint_feedback.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
-class ArmMsgJointFeedBack():
-    '''
+
+class ArmMsgJointFeedBack:
+    """
     机械臂腕部关节反馈
-    '''
-    def __init__(self, joint_1: int=0, joint_2: int=0, 
-                 joint_3: int=0, joint_4: int=0, 
-                 joint_5: int=0, joint_6: int=0):
+    """
+
+    def __init__(
+        self,
+        joint_1: int = 0,
+        joint_2: int = 0,
+        joint_3: int = 0,
+        joint_4: int = 0,
+        joint_5: int = 0,
+        joint_6: int = 0,
+    ):
         self.joint_1 = joint_1
         self.joint_2 = joint_2
         self.joint_3 = joint_3
@@ -23,13 +31,15 @@ class ArmMsgJointFeedBack():
             ("Joint 3", self.joint_3, self.joint_3 * 0.001),
             ("Joint 4", self.joint_4, self.joint_4 * 0.001),
             ("Joint 5", self.joint_5, self.joint_5 * 0.001),
-            ("Joint 6", self.joint_6, self.joint_6 * 0.001)
+            ("Joint 6", self.joint_6, self.joint_6 * 0.001),
         ]
 
         # 生成格式化字符串，保留三位小数
-        formatted_angles = "\n".join([f"{name}:{angle}, {angle_f:.3f}" for name, angle, angle_f in joint_angles])
-        
+        formatted_angles = "\n".join(
+            [f"{name}:{angle}, {angle_f:.3f}" for name, angle, angle_f in joint_angles]
+        )
+
         return f"ArmMsgJointFeedBack:\n{formatted_angles}"
-    
+
     def __repr__(self):
         return self.__str__()

--- a/piper_msgs/msg_v1/feedback/arm_low_spd_feedback.py
+++ b/piper_msgs/msg_v1/feedback/arm_low_spd_feedback.py
@@ -4,8 +4,10 @@ import math
 from typing_extensions import (
     Literal,
 )
+
+
 class ArmLowSpdFeedback:
-    '''
+    """
     驱动器信息高速反馈 0x6
 
     节点 ID: 0x1~0x06
@@ -27,20 +29,24 @@ class ArmLowSpdFeedback:
         bit[7] 堵转保护状态(0: 没有回零 1:已经回零,或已经回过零)-7.25修改，之前为回零状态
     :Byte 6: 母线电流高八位, uint16, 当前驱动器电流单位: 0.001A
     :Byte 7: 母线电流低八位
-    '''
-    def __init__(self, 
-                 can_id:Literal[0x000,0x261,0x262,0x263,0x264,0x264,0x265,0x266]=0,
-                 vol:int=0, 
-                 foc_temp:int=0, 
-                 motor_temp: int=0,
-                 foc_status: int=0,
-                 bus_current: int=0,
-                 ):
+    """
+
+    def __init__(
+        self,
+        can_id: Literal[0x000, 0x261, 0x262, 0x263, 0x264, 0x264, 0x265, 0x266] = 0,
+        vol: int = 0,
+        foc_temp: int = 0,
+        motor_temp: int = 0,
+        foc_status: int = 0,
+        bus_current: int = 0,
+    ):
         """
         初始化 ArmLowSpdFeedback 实例。
         """
-        if can_id not in [0x000,0x261,0x262,0x263,0x264,0x264,0x265,0x266]:
-            raise ValueError(f"can_id 值 {can_id} 不在范围 [0x000,0x261,0x262,0x263,0x264,0x264,0x265,0x266]")
+        if can_id not in [0x000, 0x261, 0x262, 0x263, 0x264, 0x264, 0x265, 0x266]:
+            raise ValueError(
+                f"can_id 值 {can_id} 不在范围 [0x000,0x261,0x262,0x263,0x264,0x264,0x265,0x266]"
+            )
         self.can_id = can_id
         self.vol = vol
         self.foc_temp = foc_temp
@@ -51,24 +57,26 @@ class ArmLowSpdFeedback:
 
     class FOC_Status:
         def __init__(self):
-            self.voltage_too_low  = False
+            self.voltage_too_low = False
             self.motor_overheating = False
             self.driver_overcurrent = False
             self.driver_overheating = False
             self.sensor_status = False
             self.driver_error_status = False
             self.driver_enable_status = False
-            self.homing_status  = False
-        def __str__(self): 
-            return (f"    voltage_too_low : {self.voltage_too_low}\n"
-                    f"    motor_overheating: {self.motor_overheating}\n"
-                    f"    driver_overcurrent: {self.driver_overcurrent}\n"
-                    f"    driver_overheating: {self.driver_overheating}\n"
-                    f"    sensor_status: {self.sensor_status}\n"
-                    f"    driver_error_status: {self.driver_error_status}\n"
-                    f"    driver_enable_status: {self.driver_enable_status}\n"
-                    f"    homing_status: {self.homing_status}\n"
-                    )
+            self.homing_status = False
+
+        def __str__(self):
+            return (
+                f"    voltage_too_low : {self.voltage_too_low}\n"
+                f"    motor_overheating: {self.motor_overheating}\n"
+                f"    driver_overcurrent: {self.driver_overcurrent}\n"
+                f"    driver_overheating: {self.driver_overheating}\n"
+                f"    sensor_status: {self.sensor_status}\n"
+                f"    driver_error_status: {self.driver_error_status}\n"
+                f"    driver_enable_status: {self.driver_enable_status}\n"
+                f"    homing_status: {self.homing_status}\n"
+            )
 
     @property
     def foc_status_code(self):
@@ -77,7 +85,9 @@ class ArmLowSpdFeedback:
     @foc_status_code.setter
     def foc_status_code(self, value: int):
         if not (0 <= value < 2**8):
-            raise ValueError("foc_status_code must be an 8-bit integer between 0 and 255.")
+            raise ValueError(
+                "foc_status_code must be an 8-bit integer between 0 and 255."
+            )
         self._foc_status_code = value
         # Update foc_status based on the foc_status_code bits
         self.foc_status.voltage_too_low = bool(value & (1 << 0))
@@ -93,14 +103,16 @@ class ArmLowSpdFeedback:
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"ArmLowSpdFeedback(\n"
-                f"  can_id: {hex(self.can_id)},\n"
-                f"  vol: {self.vol}, {self.vol*0.1:.1f}V,\n"
-                f"  foc_temp: {self.foc_temp }C,\n"
-                f"  motor_temp: {self.motor_temp }C,\n"
-                f"  foc_status: \n{self.foc_status },\n"
-                f"  bus_current: {self.bus_current}, {self.bus_current*0.001:.1f}A\n"
-                f")")
+        return (
+            f"ArmLowSpdFeedback(\n"
+            f"  can_id: {hex(self.can_id)},\n"
+            f"  vol: {self.vol}, {self.vol*0.1:.1f}V,\n"
+            f"  foc_temp: {self.foc_temp }C,\n"
+            f"  motor_temp: {self.motor_temp }C,\n"
+            f"  foc_status: \n{self.foc_status },\n"
+            f"  bus_current: {self.bus_current}, {self.bus_current*0.001:.1f}A\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/feedback/arm_low_spd_feedback.py
+++ b/piper_msgs/msg_v1/feedback/arm_low_spd_feedback.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
-import math
 from typing_extensions import (
     Literal,
 )

--- a/piper_msgs/msg_v1/feedback/arm_status.py
+++ b/piper_msgs/msg_v1/feedback/arm_status.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
+
 class ArmMsgStatus:
-    '''
+    """
     机械臂状态
-    '''
-    
+    """
+
     def __init__(self):
         self._err_code = 0
         self.err_status = self.ErrStatus()
-        self.ctrl_mode:int=0       #控制模式
-        self.arm_status:int=0      #机械臂状态
-        self.mode_feed:int=0       #模式反馈
-        self.teach_status:int=0    #示教状态
-        self.motion_status:int=0   #运动状态
-        self.trajectory_num:int=0  #运动速度比率
+        self.ctrl_mode: int = 0  # 控制模式
+        self.arm_status: int = 0  # 机械臂状态
+        self.mode_feed: int = 0  # 模式反馈
+        self.teach_status: int = 0  # 示教状态
+        self.motion_status: int = 0  # 运动状态
+        self.trajectory_num: int = 0  # 运动速度比率
 
     class ErrStatus:
         def __init__(self):
@@ -30,20 +31,22 @@ class ArmMsgStatus:
             self.communication_status_joint_4 = False
             self.communication_status_joint_5 = False
             self.communication_status_joint_6 = False
-            
+
         def __str__(self):
-            return (f" Joint 1 Angle Limit Status: {self.joint_1_angle_limit}\n"
-                    f" Joint 2 Angle Limit Status: {self.joint_2_angle_limit}\n"
-                    f" Joint 3 Angle Limit Status: {self.joint_3_angle_limit}\n"
-                    f" Joint 4 Angle Limit Status: {self.joint_4_angle_limit}\n"
-                    f" Joint 5 Angle Limit Status: {self.joint_5_angle_limit}\n"
-                    f" Joint 6 Angle Limit Status: {self.joint_6_angle_limit}\n"
-                    f" Joint 1 Communication Status: {self.communication_status_joint_1}\n"
-                    f" Joint 2 Communication Status: {self.communication_status_joint_2}\n"
-                    f" Joint 3 Communication Status: {self.communication_status_joint_3}\n"
-                    f" Joint 4 Communication Status: {self.communication_status_joint_4}\n"
-                    f" Joint 5 Communication Status: {self.communication_status_joint_5}\n"
-                    f" Joint 6 Communication Status: {self.communication_status_joint_6}\n")
+            return (
+                f" Joint 1 Angle Limit Status: {self.joint_1_angle_limit}\n"
+                f" Joint 2 Angle Limit Status: {self.joint_2_angle_limit}\n"
+                f" Joint 3 Angle Limit Status: {self.joint_3_angle_limit}\n"
+                f" Joint 4 Angle Limit Status: {self.joint_4_angle_limit}\n"
+                f" Joint 5 Angle Limit Status: {self.joint_5_angle_limit}\n"
+                f" Joint 6 Angle Limit Status: {self.joint_6_angle_limit}\n"
+                f" Joint 1 Communication Status: {self.communication_status_joint_1}\n"
+                f" Joint 2 Communication Status: {self.communication_status_joint_2}\n"
+                f" Joint 3 Communication Status: {self.communication_status_joint_3}\n"
+                f" Joint 4 Communication Status: {self.communication_status_joint_4}\n"
+                f" Joint 5 Communication Status: {self.communication_status_joint_5}\n"
+                f" Joint 6 Communication Status: {self.communication_status_joint_6}\n"
+            )
 
     @property
     def err_code(self):
@@ -69,14 +72,16 @@ class ArmMsgStatus:
         self.err_status.communication_status_joint_6 = bool(value & (1 << 13))
 
     def __str__(self):
-        return (f"Control Mode: {self.ctrl_mode}\n"
-                f"Arm Status: {self.arm_status}\n"
-                f"Mode Feed: {self.mode_feed}\n"
-                f"Teach Status: {self.teach_status}\n"
-                f"Motion Status: {self.motion_status}\n"
-                f"Trajectory Num: {self.trajectory_num}\n"
-                f"Error Code: {self._err_code}\n"
-                f"Error Status: \n{self.err_status}\n")
+        return (
+            f"Control Mode: {self.ctrl_mode}\n"
+            f"Arm Status: {self.arm_status}\n"
+            f"Mode Feed: {self.mode_feed}\n"
+            f"Teach Status: {self.teach_status}\n"
+            f"Motion Status: {self.motion_status}\n"
+            f"Trajectory Num: {self.trajectory_num}\n"
+            f"Error Code: {self._err_code}\n"
+            f"Error Status: \n{self.err_status}\n"
+        )
 
     def __repr__(self):
         return self.__str__()

--- a/piper_msgs/msg_v1/feedback/gripper_feedback.py
+++ b/piper_msgs/msg_v1/feedback/gripper_feedback.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
+
 class ArmMsgGripperFeedBack:
-    '''
+    """
     夹爪反馈消息
-    '''
-    def __init__(self, grippers_angle: int=0, grippers_effort: int=0, status_code: int=0):
+    """
+
+    def __init__(
+        self, grippers_angle: int = 0, grippers_effort: int = 0, status_code: int = 0
+    ):
         """
         初始化 ArmMsgGripperFeedBack 实例。
 
@@ -17,27 +21,30 @@ class ArmMsgGripperFeedBack:
         self.grippers_effort = grippers_effort
         self._status_code = status_code
         self.foc_status = self.FOC_Status()
-    
+
     class FOC_Status:
         def __init__(self):
-            self.voltage_too_low  = False
+            self.voltage_too_low = False
             self.motor_overheating = False
             self.driver_overcurrent = False
             self.driver_overheating = False
             self.sensor_status = False
             self.driver_error_status = False
             self.driver_enable_status = False
-            self.homing_status  = False
-        def __str__(self): 
-            return (f"    voltage_too_low : {self.voltage_too_low}\n"
-                    f"    motor_overheating: {self.motor_overheating}\n"
-                    f"    driver_overcurrent: {self.driver_overcurrent}\n"
-                    f"    driver_overheating: {self.driver_overheating}\n"
-                    f"    sensor_status: {self.sensor_status}\n"
-                    f"    driver_error_status: {self.driver_error_status}\n"
-                    f"    driver_enable_status: {self.driver_enable_status}\n"
-                    f"    homing_status: {self.homing_status}\n"
-                    )
+            self.homing_status = False
+
+        def __str__(self):
+            return (
+                f"    voltage_too_low : {self.voltage_too_low}\n"
+                f"    motor_overheating: {self.motor_overheating}\n"
+                f"    driver_overcurrent: {self.driver_overcurrent}\n"
+                f"    driver_overheating: {self.driver_overheating}\n"
+                f"    sensor_status: {self.sensor_status}\n"
+                f"    driver_error_status: {self.driver_error_status}\n"
+                f"    driver_enable_status: {self.driver_enable_status}\n"
+                f"    homing_status: {self.homing_status}\n"
+            )
+
     @property
     def status_code(self):
         return self._status_code
@@ -56,18 +63,20 @@ class ArmMsgGripperFeedBack:
         self.foc_status.driver_error_status = bool(value & (1 << 5))
         self.foc_status.driver_enable_status = bool(value & (1 << 6))
         self.foc_status.homing_status = bool(value & (1 << 7))
-    
+
     def __str__(self):
         """
         返回对象的字符串表示，用于打印。
 
         :return: 格式化的字符串表示夹爪的角度、速度和状态码。
         """
-        return (f"ArmMsgGripperFeedBack(\n"
-                f"  grippers_angle: {self.grippers_angle}, {self.grippers_angle * 0.001:.3f},\n"
-                f"  grippers_effort: {self.grippers_effort} \t {self.grippers_effort * 0.001:.2f},\n"
-                f"  status_code: \n{self.foc_status}\n"
-                f")")
+        return (
+            f"ArmMsgGripperFeedBack(\n"
+            f"  grippers_angle: {self.grippers_angle}, {self.grippers_angle * 0.001:.3f},\n"
+            f"  grippers_effort: {self.grippers_effort} \t {self.grippers_effort * 0.001:.2f},\n"
+            f"  status_code: \n{self.foc_status}\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/transmit/arm_circular_pattern.py
+++ b/piper_msgs/msg_v1/transmit/arm_circular_pattern.py
@@ -4,8 +4,9 @@ from typing_extensions import (
     Literal,
 )
 
+
 class ArmMsgCircularPatternCoordNumUpdateCtrl:
-    '''
+    """
     圆弧模式坐标序号更新指令
 
     :Byte 0 instruction_num: uint8, 指令点序号,以整数表示。
@@ -13,8 +14,9 @@ class ArmMsgCircularPatternCoordNumUpdateCtrl:
                             0x01 起点
                             0x02 中点
                             0x03 终点
-    '''
-    def __init__(self, instruction_num:Literal[0x00, 0x01, 0x02, 0x03]=0x00):
+    """
+
+    def __init__(self, instruction_num: Literal[0x00, 0x01, 0x02, 0x03] = 0x00):
         """
         初始化 ArmMsgCircularPatternCoordNumUpdateCtrl 实例。
 
@@ -25,7 +27,9 @@ class ArmMsgCircularPatternCoordNumUpdateCtrl:
                                 0x03 终点
         """
         if instruction_num not in [0x00, 0x01, 0x02, 0x03]:
-            raise ValueError(f"instruction_num 值 {instruction_num} 超出范围 [0x00, 0x01, 0x02, 0x03]")
+            raise ValueError(
+                f"instruction_num 值 {instruction_num} 超出范围 [0x00, 0x01, 0x02, 0x03]"
+            )
         self.instruction_num = instruction_num
 
     def __str__(self):
@@ -34,9 +38,11 @@ class ArmMsgCircularPatternCoordNumUpdateCtrl:
 
         :return: 格式化的字符串
         """
-        return (f"ArmMsgCircularPatternCoordNumUpdateCtrl(\n"
-                f"  instruction_num: {self.instruction_num},\n"
-                f")")
+        return (
+            f"ArmMsgCircularPatternCoordNumUpdateCtrl(\n"
+            f"  instruction_num: {self.instruction_num},\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/transmit/arm_crash_protection_rating_config.py
+++ b/piper_msgs/msg_v1/transmit/arm_crash_protection_rating_config.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
+
 class ArmMsgCrashProtectionRatingConfig:
-    '''
+    """
     末端速度/加速度参数设置指令
-    
+
     0x47A
 
     有效值 : 0~8
@@ -19,15 +20,17 @@ class ArmMsgCrashProtectionRatingConfig:
     :Byte 5: 6 号关节碰撞防护等级, uint8
     :Byte 6: 保留
     :Byte 7: 保留
-    '''
-    def __init__(self, 
-                 jonit_1_protection_level:int=0xFF, 
-                 jonit_2_protection_level:int=0xFF, 
-                 jonit_3_protection_level: int=0xFF,
-                 jonit_4_protection_level: int=0xFF,
-                 jonit_5_protection_level: int=0xFF,
-                 jonit_6_protection_level: int=0xFF
-                 ):
+    """
+
+    def __init__(
+        self,
+        jonit_1_protection_level: int = 0xFF,
+        jonit_2_protection_level: int = 0xFF,
+        jonit_3_protection_level: int = 0xFF,
+        jonit_4_protection_level: int = 0xFF,
+        jonit_5_protection_level: int = 0xFF,
+        jonit_6_protection_level: int = 0xFF,
+    ):
         """
         初始化 ArmMsgCrashProtectionRatingConfig 实例。
         """
@@ -42,14 +45,16 @@ class ArmMsgCrashProtectionRatingConfig:
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"ArmMsgCrashProtectionRatingConfig(\n"
-                f"  jonit_1_protection_level: {self.jonit_1_protection_level},\n"
-                f"  jonit_2_protection_level: {self.jonit_2_protection_level},\n"
-                f"  jonit_3_protection_level: {self.jonit_3_protection_level},\n"
-                f"  jonit_4_protection_level: {self.jonit_4_protection_level},\n"
-                f"  jonit_5_protection_level: {self.jonit_5_protection_level},\n"
-                f"  jonit_6_protection_level: {self.jonit_6_protection_level}\n"
-                f")")
+        return (
+            f"ArmMsgCrashProtectionRatingConfig(\n"
+            f"  jonit_1_protection_level: {self.jonit_1_protection_level},\n"
+            f"  jonit_2_protection_level: {self.jonit_2_protection_level},\n"
+            f"  jonit_3_protection_level: {self.jonit_3_protection_level},\n"
+            f"  jonit_4_protection_level: {self.jonit_4_protection_level},\n"
+            f"  jonit_5_protection_level: {self.jonit_5_protection_level},\n"
+            f"  jonit_6_protection_level: {self.jonit_6_protection_level}\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/transmit/arm_end_vel_acc_param_config.py
+++ b/piper_msgs/msg_v1/transmit/arm_end_vel_acc_param_config.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
+
 class ArmMsgEndVelAccParamConfig:
-    '''
+    """
     末端速度/加速度参数设置指令
-    
+
     0x479
 
     :Byte 0: 末端最大线速度 H, uint16, 单位 0.001m/s
@@ -15,18 +16,20 @@ class ArmMsgEndVelAccParamConfig:
     :Byte 5: 末端最大线加速度 L
     :Byte 6: 末端最大角加速度 H, uint16, 单位 0.001rad/s^2
     :Byte 7: 末端最大角加速度 L
-    '''
-    def __init__(self, 
-                 end_max_linear_vel:int=0, 
-                 end_max_angular_vel:int=0, 
-                 end_max_linear_acc: int=0,
-                 end_max_angular_acc: int=0
-                 ):
+    """
+
+    def __init__(
+        self,
+        end_max_linear_vel: int = 0,
+        end_max_angular_vel: int = 0,
+        end_max_linear_acc: int = 0,
+        end_max_angular_acc: int = 0,
+    ):
         """
         初始化 ArmMsgEndVelAccParamConfig 实例。
 
         末端速度/加速度参数设置指令
-    
+
         0x479
 
         :Byte 0: 末端最大线速度 H, uint16, 单位 0.001m/s
@@ -47,12 +50,14 @@ class ArmMsgEndVelAccParamConfig:
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"ArmMsgEndVelAccParamConfig(\n"
-                f"  end_max_linear_vel: {self.end_max_linear_vel * 0.001:.3f},\n"
-                f"  end_max_angular_vel: {self.end_max_angular_vel * 0.001:.3f},\n"
-                f"  end_max_linear_acc: {self.end_max_linear_acc * 0.001:.3f},\n"
-                f"  end_max_angular_acc: {self.end_max_angular_acc * 0.001:.3f}\n"
-                f")")
+        return (
+            f"ArmMsgEndVelAccParamConfig(\n"
+            f"  end_max_linear_vel: {self.end_max_linear_vel * 0.001:.3f},\n"
+            f"  end_max_angular_vel: {self.end_max_angular_vel * 0.001:.3f},\n"
+            f"  end_max_linear_acc: {self.end_max_linear_acc * 0.001:.3f},\n"
+            f"  end_max_angular_acc: {self.end_max_angular_acc * 0.001:.3f}\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/transmit/arm_gripper_ctrl.py
+++ b/piper_msgs/msg_v1/transmit/arm_gripper_ctrl.py
@@ -3,15 +3,20 @@
 from typing_extensions import (
     Literal,
 )
+
+
 class ArmMsgGripperCtrl:
-    '''
+    """
     夹爪发送消息
-    '''
-    def __init__(self, 
-                 grippers_angle: int=0, 
-                 grippers_effort: int=0, 
-                 status_code: Literal[0x00,0x01,0x02,0x03]=0,
-                 set_zero: Literal[0x00,0xAE]=0):
+    """
+
+    def __init__(
+        self,
+        grippers_angle: int = 0,
+        grippers_effort: int = 0,
+        status_code: Literal[0x00, 0x01, 0x02, 0x03] = 0,
+        set_zero: Literal[0x00, 0xAE] = 0,
+    ):
         """
         初始化 ArmMsgGripperCtrl 实例。
 
@@ -27,7 +32,9 @@ class ArmMsgGripperCtrl:
         :Byte 6 set_zero: uint8, 设定当前位置为0点
         """
         if status_code not in [0x00, 0x01, 0x02, 0x03]:
-            raise ValueError(f"status_code 值 {status_code} 超出范围 [0x00, 0x01, 0x02, 0x03]")
+            raise ValueError(
+                f"status_code 值 {status_code} 超出范围 [0x00, 0x01, 0x02, 0x03]"
+            )
         self.grippers_angle = grippers_angle
         self.grippers_effort = grippers_effort
         self.status_code = status_code
@@ -38,12 +45,14 @@ class ArmMsgGripperCtrl:
         返回对象的字符串表示，用于打印。
         :return: 格式化的字符串表示夹爪的角度、速度和状态码。
         """
-        return (f"ArmMsgGripperCtrl(\n"
-                f"  grippers_angle: {self.grippers_angle * 0.001:.3f},\n"
-                f"  grippers_effort: {self.grippers_effort * 0.01:.2f},\n"
-                f"  status_code: {self.status_code},\n"
-                f"  set_zero: {self.set_zero}\n"
-                f")")
+        return (
+            f"ArmMsgGripperCtrl(\n"
+            f"  grippers_angle: {self.grippers_angle * 0.001:.3f},\n"
+            f"  grippers_effort: {self.grippers_effort * 0.01:.2f},\n"
+            f"  status_code: {self.status_code},\n"
+            f"  set_zero: {self.set_zero}\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/transmit/arm_joint_config.py
+++ b/piper_msgs/msg_v1/transmit/arm_joint_config.py
@@ -3,13 +3,15 @@
 from typing_extensions import (
     Literal,
 )
+
+
 class ArmMsgJointConfig:
-    '''
+    """
     关节设置指令
 
     0x475
 
-    :Byte 0 关节电机序号 uint8, 值域 1-7:   
+    :Byte 0 关节电机序号 uint8, 值域 1-7:
                               1-6 代表关节驱动器序号；
                               7 代表全部关节电机
     :Byte 1 设置N号电机当前位置为零点: uint8, 有效值 : 0xAE
@@ -17,40 +19,51 @@ class ArmMsgJointConfig:
     :Byte 3 最大关节加速度 H: uint16, 单位 0.001rad/s
     :Byte 4 最大关节加速度 L
     :Byte 5 清除关节错误代码: uint8, 有效值 : 0xAE
-    '''
-    def __init__(self, 
-                 joint_motor_num:Literal[1, 2, 3, 4, 5, 6, 7]=7, 
-                 set_motor_current_pos_as_zero: Literal[0x00, 0xAE]=0, 
-                 acc_param_config_is_effective_or_not: Literal[0x00, 0xAE]=0,
-                 max_joint_acc: int=0,
-                 clear_joint_err: Literal[0x00, 0xAE]=0):
+    """
+
+    def __init__(
+        self,
+        joint_motor_num: Literal[1, 2, 3, 4, 5, 6, 7] = 7,
+        set_motor_current_pos_as_zero: Literal[0x00, 0xAE] = 0,
+        acc_param_config_is_effective_or_not: Literal[0x00, 0xAE] = 0,
+        max_joint_acc: int = 0,
+        clear_joint_err: Literal[0x00, 0xAE] = 0,
+    ):
         """
-        初始化 ArmMsgMotorAngleSpdLimitConfig 实例。
+            初始化 ArmMsgMotorAngleSpdLimitConfig 实例。
 
-        关节设置指令
+            关节设置指令
 
-        0x475
+            0x475
 
-        :Byte 0 关节电机序号 uint8, 值域 1-7:   
-                                1-6 代表关节驱动器序号；
-                                7 代表全部关节电机
-        :Byte 1 设置N号电机当前位置为零点: uint8, 有效值 : 0xAE
-        :Byte 2 加速度参数设置是否生效: uint8, 有效值 : 0xAE
-        :Byte 3 最大关节加速度 H: uint16, 单位 0.001rad/s
-        :Byte 4 最大关节加速度 L
-    :Byte 5 清除关节错误代码: uint8, 有效值 : 0xAE
-        
+            :Byte 0 关节电机序号 uint8, 值域 1-7:
+                                    1-6 代表关节驱动器序号；
+                                    7 代表全部关节电机
+            :Byte 1 设置N号电机当前位置为零点: uint8, 有效值 : 0xAE
+            :Byte 2 加速度参数设置是否生效: uint8, 有效值 : 0xAE
+            :Byte 3 最大关节加速度 H: uint16, 单位 0.001rad/s
+            :Byte 4 最大关节加速度 L
+        :Byte 5 清除关节错误代码: uint8, 有效值 : 0xAE
+
         """
         if joint_motor_num not in [1, 2, 3, 4, 5, 6, 7]:
-            raise ValueError(f"joint_motor_num 值 {joint_motor_num} 超出范围 [1, 2, 3, 4, 5, 6, 7]")
+            raise ValueError(
+                f"joint_motor_num 值 {joint_motor_num} 超出范围 [1, 2, 3, 4, 5, 6, 7]"
+            )
         if set_motor_current_pos_as_zero not in [0x00, 0xAE]:
-            raise ValueError(f"set_motor_current_pos_as_zero 值 {set_motor_current_pos_as_zero} 超出范围 [0x00, 0xAE]")
+            raise ValueError(
+                f"set_motor_current_pos_as_zero 值 {set_motor_current_pos_as_zero} 超出范围 [0x00, 0xAE]"
+            )
         if acc_param_config_is_effective_or_not not in [0x00, 0xAE]:
-            raise ValueError(f"acc_param_config_is_effective_or_not 值 {acc_param_config_is_effective_or_not} 超出范围 [0x00, 0xAE]")
+            raise ValueError(
+                f"acc_param_config_is_effective_or_not 值 {acc_param_config_is_effective_or_not} 超出范围 [0x00, 0xAE]"
+            )
         if not (0 <= max_joint_acc <= 65535):
             raise ValueError(f"max_joint_acc 值 {max_joint_acc} 超出范围 [0, 65535]")
         if clear_joint_err not in [0x00, 0xAE]:
-            raise ValueError(f"clear_joint_err 值 {clear_joint_err} 超出范围 [0x00, 0xAE]")
+            raise ValueError(
+                f"clear_joint_err 值 {clear_joint_err} 超出范围 [0x00, 0xAE]"
+            )
         self.joint_motor_num = joint_motor_num
         self.set_motor_current_pos_as_zero = set_motor_current_pos_as_zero
         self.acc_param_config_is_effective_or_not = acc_param_config_is_effective_or_not
@@ -61,13 +74,15 @@ class ArmMsgJointConfig:
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"ArmMsgJointConfig(\n"
-                f"  joint_motor_num: {self.joint_motor_num},\n"
-                f"  set_motor_current_pos_as_zero: {self.set_motor_current_pos_as_zero},\n"
-                f"  acc_param_config_is_effective_or_not: {self.acc_param_config_is_effective_or_not},\n"
-                f"  max_joint_acc: {self.max_joint_acc}, {self.max_joint_acc*0.001:.3f}\n"
-                f"  clear_joint_err: {self.clear_joint_err}\n"
-                f")")
+        return (
+            f"ArmMsgJointConfig(\n"
+            f"  joint_motor_num: {self.joint_motor_num},\n"
+            f"  set_motor_current_pos_as_zero: {self.set_motor_current_pos_as_zero},\n"
+            f"  acc_param_config_is_effective_or_not: {self.acc_param_config_is_effective_or_not},\n"
+            f"  max_joint_acc: {self.max_joint_acc}, {self.max_joint_acc*0.001:.3f}\n"
+            f"  clear_joint_err: {self.clear_joint_err}\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/transmit/arm_joint_ctrl.py
+++ b/piper_msgs/msg_v1/transmit/arm_joint_ctrl.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
-class ArmMsgJointCtrl():
-    '''
+
+class ArmMsgJointCtrl:
+    """
     机械臂腕部关节控制
-    '''
-    def __init__(self, joint_1: int=0, joint_2: int=0, 
-                 joint_3: int=0, joint_4: int=0, 
-                 joint_5: int=0, joint_6: int=0):
+    """
+
+    def __init__(
+        self,
+        joint_1: int = 0,
+        joint_2: int = 0,
+        joint_3: int = 0,
+        joint_4: int = 0,
+        joint_5: int = 0,
+        joint_6: int = 0,
+    ):
         self.joint_1 = joint_1
         self.joint_2 = joint_2
         self.joint_3 = joint_3
@@ -23,13 +31,15 @@ class ArmMsgJointCtrl():
             ("Joint_3", self.joint_3 * 0.001),
             ("Joint_4", self.joint_4 * 0.001),
             ("Joint_5", self.joint_5 * 0.001),
-            ("Joint_6", self.joint_6 * 0.001)
+            ("Joint_6", self.joint_6 * 0.001),
         ]
 
         # 生成格式化字符串，保留三位小数
-        formatted_angles = "\n".join([f"{name}: {angle:.3f}" for name, angle in joint_angles])
-        
+        formatted_angles = "\n".join(
+            [f"{name}: {angle:.3f}" for name, angle in joint_angles]
+        )
+
         return f"ArmMsgJointCtrl:\n{formatted_angles}"
-    
+
     def __repr__(self):
         return self.__str__()

--- a/piper_msgs/msg_v1/transmit/arm_master_slave_config.py
+++ b/piper_msgs/msg_v1/transmit/arm_master_slave_config.py
@@ -4,15 +4,19 @@ from typing_extensions import (
     Literal,
 )
 
+
 class ArmMsgMasterSlaveModeConfig:
-    '''
+    """
     随动主从模式设置指令
-    '''
-    def __init__(self, 
-                 linkage_config:Literal[0x00, 0xFA, 0xFC]=0x00,
-                 feedback_offset:Literal[0x00, 0x10, 0x20]=0x00,
-                 ctrl_offset:Literal[0x00, 0x10, 0x20]=0x00,
-                 linkage_offset:Literal[0x00, 0x10, 0x20]=0x00):
+    """
+
+    def __init__(
+        self,
+        linkage_config: Literal[0x00, 0xFA, 0xFC] = 0x00,
+        feedback_offset: Literal[0x00, 0x10, 0x20] = 0x00,
+        ctrl_offset: Literal[0x00, 0x10, 0x20] = 0x00,
+        linkage_offset: Literal[0x00, 0x10, 0x20] = 0x00,
+    ):
         """
         初始化 ArmMsgMasterSlaveModeConfig 实例。
 
@@ -34,13 +38,21 @@ class ArmMsgMasterSlaveModeConfig:
                                 0x20 : 控制目标地址基 ID由 15x 偏移为 17x
         """
         if linkage_config not in [0x00, 0xFA, 0xFC]:
-            raise ValueError(f"linkage_config 值 {linkage_config} 超出范围 [0x00, 0xFA, 0xFC]")
+            raise ValueError(
+                f"linkage_config 值 {linkage_config} 超出范围 [0x00, 0xFA, 0xFC]"
+            )
         if feedback_offset not in [0x00, 0x10, 0x20]:
-            raise ValueError(f"feedback_offset 值 {feedback_offset} 超出范围 [0x00, 0x10, 0x20]")
+            raise ValueError(
+                f"feedback_offset 值 {feedback_offset} 超出范围 [0x00, 0x10, 0x20]"
+            )
         if ctrl_offset not in [0x00, 0x10, 0x20]:
-            raise ValueError(f"ctrl_offset 值 {ctrl_offset} 超出范围 [0x00, 0x10, 0x20]")
+            raise ValueError(
+                f"ctrl_offset 值 {ctrl_offset} 超出范围 [0x00, 0x10, 0x20]"
+            )
         if linkage_offset not in [0x00, 0x10, 0x20]:
-            raise ValueError(f"linkage_offset 值 {linkage_offset} 超出范围 [0x00, 0x10, 0x20]")
+            raise ValueError(
+                f"linkage_offset 值 {linkage_offset} 超出范围 [0x00, 0x10, 0x20]"
+            )
         self.linkage_config = linkage_config
         self.feedback_offset = feedback_offset
         self.ctrl_offset = ctrl_offset
@@ -52,12 +64,14 @@ class ArmMsgMasterSlaveModeConfig:
 
         :return: 格式化的字符串
         """
-        return (f"ArmMsgMasterSlaveModeConfig(\n"
-                f"  linkage_config: {self.linkage_config },\n"
-                f"  feedback_offset: {self.feedback_offset },\n"
-                f"  ctrl_offset: {self.ctrl_offset },\n"
-                f"  linkage_offset: {self.linkage_offset}\n"
-                f")")
+        return (
+            f"ArmMsgMasterSlaveModeConfig(\n"
+            f"  linkage_config: {self.linkage_config },\n"
+            f"  feedback_offset: {self.feedback_offset },\n"
+            f"  ctrl_offset: {self.ctrl_offset },\n"
+            f"  linkage_offset: {self.linkage_offset}\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/transmit/arm_motion_ctrl_1.py
+++ b/piper_msgs/msg_v1/transmit/arm_motion_ctrl_1.py
@@ -3,8 +3,10 @@
 from typing_extensions import (
     Literal,
 )
-class ArmMsgMotionCtrl_1():
-    '''
+
+
+class ArmMsgMotionCtrl_1:
+    """
     机械臂运动控制指令1
     Byte 0 快速急停     uint8    0x00 无效
                                 0x01 快速急停
@@ -30,23 +32,32 @@ class ArmMsgMotionCtrl_1():
                                 N=0~255
                                 主控收到后会应答0x476 byte0 = 0x50 ;byte 2=N(详见0x476 )未收到应答需要重传
     Byte 4 NameIndex_H uint16   当前轨迹包名称索引,由NameIndex和crc组成(应答0x477 byte0=03)
-    Byte 5 crc16       uint16   
-    '''
-    def __init__(self, 
-                 emergency_stop:Literal[0x00, 0x01, 0x02]=0, 
-                 track_ctrl:Literal[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]=0, 
-                 grag_teach_ctrl:Literal[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]=0):
+    Byte 5 crc16       uint16
+    """
+
+    def __init__(
+        self,
+        emergency_stop: Literal[0x00, 0x01, 0x02] = 0,
+        track_ctrl: Literal[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08] = 0,
+        grag_teach_ctrl: Literal[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07] = 0,
+    ):
         # 检查 emergency_stop 是否在有效范围内
         if emergency_stop not in [0x00, 0x01, 0x02]:
-            raise ValueError(f"emergency_stop 值 {emergency_stop} 超出范围 [0x00, 0x01, 0x02]")
-        
+            raise ValueError(
+                f"emergency_stop 值 {emergency_stop} 超出范围 [0x00, 0x01, 0x02]"
+            )
+
         # 检查 track_ctrl 是否在有效范围内
         if track_ctrl not in [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]:
-            raise ValueError(f"track_ctrl 值 {track_ctrl} 超出范围 [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]")
-        
+            raise ValueError(
+                f"track_ctrl 值 {track_ctrl} 超出范围 [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]"
+            )
+
         # 检查 grag_teach_ctrl 是否在有效范围内
         if grag_teach_ctrl not in [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]:
-            raise ValueError(f"grag_teach_ctrl 值 {grag_teach_ctrl} 超出范围 [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]")
+            raise ValueError(
+                f"grag_teach_ctrl 值 {grag_teach_ctrl} 超出范围 [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]"
+            )
         self.emergency_stop = emergency_stop
         self.track_ctrl = track_ctrl
         self.grag_teach_ctrl = grag_teach_ctrl
@@ -55,13 +66,13 @@ class ArmMsgMotionCtrl_1():
         dict_ = [
             (" emergency_stop ", self.emergency_stop),
             (" track_ctrl ", self.track_ctrl),
-            (" grag_teach_ctrl ", self.grag_teach_ctrl)
+            (" grag_teach_ctrl ", self.grag_teach_ctrl),
         ]
 
         # 生成格式化字符串，保留三位小数
         formatted_ = "\n".join([f"{name}: {value}" for name, value in dict_])
-        
+
         return f"ArmMsgMotionCtrl_1:\n{formatted_}"
-    
+
     def __repr__(self):
         return self.__str__()

--- a/piper_msgs/msg_v1/transmit/arm_motion_ctrl_2.py
+++ b/piper_msgs/msg_v1/transmit/arm_motion_ctrl_2.py
@@ -3,8 +3,10 @@
 from typing_extensions import (
     Literal,
 )
-class ArmMsgMotionCtrl_2():
-    '''
+
+
+class ArmMsgMotionCtrl_2:
+    """
     机械臂运动控制指令2
 
     0x151
@@ -23,23 +25,30 @@ class ArmMsgMotionCtrl_2():
     Byte 3 mit模式      uint8    0x00 位置速度模式
                                 0xAD MIT模式
     Byte 4 离线轨迹点停留时间 uint8 0~255 单位 s
-    '''
-    def __init__(self, 
-                 ctrl_mode:Literal[0x00, 0x01, 0x02, 0x03, 0x04, 0x07]=0x01, 
-                 move_mode:Literal[0x00, 0x01, 0x02, 0x03]=0x01, 
-                 move_spd_rate_ctrl:int=50,
-                 mit_mode:Literal[0x00, 0xAD, 0xFF]=0x00,
-                 residence_time:int=0):
+    """
+
+    def __init__(
+        self,
+        ctrl_mode: Literal[0x00, 0x01, 0x02, 0x03, 0x04, 0x07] = 0x01,
+        move_mode: Literal[0x00, 0x01, 0x02, 0x03] = 0x01,
+        move_spd_rate_ctrl: int = 50,
+        mit_mode: Literal[0x00, 0xAD, 0xFF] = 0x00,
+        residence_time: int = 0,
+    ):
         # 检查是否在有效范围内
         if ctrl_mode not in [0x00, 0x01, 0x02, 0x03, 0x04, 0x07]:
-            raise ValueError(f"ctrl_mode 值 {ctrl_mode} 超出范围 [0x00, 0x01, 0x02, 0x03, 0x04, 0x07]")
+            raise ValueError(
+                f"ctrl_mode 值 {ctrl_mode} 超出范围 [0x00, 0x01, 0x02, 0x03, 0x04, 0x07]"
+            )
         if move_mode not in [0x00, 0x01, 0x02, 0x03]:
-            raise ValueError(f"move_mode 值 {move_mode} 超出范围 [0x00, 0x01, 0x02, 0x03]")
-        if not (0<= move_spd_rate_ctrl <=100):
+            raise ValueError(
+                f"move_mode 值 {move_mode} 超出范围 [0x00, 0x01, 0x02, 0x03]"
+            )
+        if not (0 <= move_spd_rate_ctrl <= 100):
             raise ValueError(f"输入的值 {move_spd_rate_ctrl} 超出范围 [0, 100]")
         if mit_mode not in [0x00, 0xAD, 0xFF]:
             raise ValueError(f"mit_mode 值 {mit_mode} 超出范围 [0x00, 0xAD, 0xFF]")
-        if not (0<= residence_time <=255):
+        if not (0 <= residence_time <= 255):
             raise ValueError(f"输入的值 {residence_time} 超出范围 [0, 255]")
         self.ctrl_mode = ctrl_mode
         self.move_mode = move_mode
@@ -53,13 +62,13 @@ class ArmMsgMotionCtrl_2():
             (" move_mode ", self.move_mode),
             (" move_spd_rate_ctrl ", self.move_spd_rate_ctrl),
             (" mit_mode ", self.mit_mode),
-            (" residence_time ", self.residence_time)
+            (" residence_time ", self.residence_time),
         ]
 
         # 生成格式化字符串，保留三位小数
         formatted_ = "\n".join([f"{name}: {value}" for name, value in dict_])
-        
+
         return f"ArmMsgMotionCtrl_2:\n{formatted_}"
-    
+
     def __repr__(self):
         return self.__str__()

--- a/piper_msgs/msg_v1/transmit/arm_motion_ctrl_cartesian.py
+++ b/piper_msgs/msg_v1/transmit/arm_motion_ctrl_cartesian.py
@@ -1,16 +1,24 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 
-class ArmMsgMotionCtrlCartesian():
-    '''
+
+class ArmMsgMotionCtrlCartesian:
+    """
     机械臂运动控制直角坐标系指令
 
     0x152,0x153,0x154
 
-    '''
-    def __init__(self, X_axis: int=0, Y_axis: int=0, 
-                 Z_axis: int=0, RX_axis: int=0, 
-                 RY_axis: int=0, RZ_axis: int=0):
+    """
+
+    def __init__(
+        self,
+        X_axis: int = 0,
+        Y_axis: int = 0,
+        Z_axis: int = 0,
+        RX_axis: int = 0,
+        RY_axis: int = 0,
+        RZ_axis: int = 0,
+    ):
         self.X_axis = X_axis
         self.Y_axis = Y_axis
         self.Z_axis = Z_axis
@@ -25,13 +33,13 @@ class ArmMsgMotionCtrlCartesian():
             (" Z_axis ", self.Z_axis),
             (" RX_axis ", self.RX_axis),
             (" RY_axis ", self.RY_axis),
-            (" RZ_axis ", self.RZ_axis)
+            (" RZ_axis ", self.RZ_axis),
         ]
 
         # 生成格式化字符串，保留三位小数
         formatted_ = "\n".join([f"{name}: {value}" for name, value in dict_])
-        
+
         return f"ArmMsgMotionCtrlCartesian:\n{formatted_}"
-    
+
     def __repr__(self):
         return self.__str__()

--- a/piper_msgs/msg_v1/transmit/arm_motor_angle_limit_max_spd_config.py
+++ b/piper_msgs/msg_v1/transmit/arm_motor_angle_limit_max_spd_config.py
@@ -3,8 +3,10 @@
 from typing_extensions import (
     Literal,
 )
+
+
 class ArmMsgMotorAngleLimitMaxSpdSet:
-    '''
+    """
     电机角度限制/最大速度设置指令
 
     0x474
@@ -16,12 +18,15 @@ class ArmMsgMotorAngleLimitMaxSpdSet:
     :Byte 4 最小角度限制 L
     :Byte 5 最大关节速度 H: uint16, 单位 0.001rad/s
     :Byte 6 最大关节速度 L
-    '''
-    def __init__(self, 
-                 motor_num:Literal[1, 2, 3, 4, 5, 6]=1, 
-                 max_angle_limit: int=0, 
-                 min_angle_limit: int=0,
-                 max_jonit_spd: int=0):
+    """
+
+    def __init__(
+        self,
+        motor_num: Literal[1, 2, 3, 4, 5, 6] = 1,
+        max_angle_limit: int = 0,
+        min_angle_limit: int = 0,
+        max_jonit_spd: int = 0,
+    ):
         """
         电机角度限制/最大速度设置指令
 
@@ -46,12 +51,14 @@ class ArmMsgMotorAngleLimitMaxSpdSet:
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"ArmMsgMotorAngleSpdLimitConfig(\n"
-                f"  motor_num: {self.motor_num},\n"
-                f"  max_angle_limit: {self.max_angle_limit}, {self.max_angle_limit * 0.1:.1f},\n"
-                f"  min_angle_limit: {self.min_angle_limit}, {self.min_angle_limit * 0.1:.1f},\n"
-                f"  max_jonit_spd: {self.max_jonit_spd}, {self.max_jonit_spd * 0.3:.3f}\n"
-                f")")
+        return (
+            f"ArmMsgMotorAngleSpdLimitConfig(\n"
+            f"  motor_num: {self.motor_num},\n"
+            f"  max_angle_limit: {self.max_angle_limit}, {self.max_angle_limit * 0.1:.1f},\n"
+            f"  min_angle_limit: {self.min_angle_limit}, {self.min_angle_limit * 0.1:.1f},\n"
+            f"  max_jonit_spd: {self.max_jonit_spd}, {self.max_jonit_spd * 0.3:.3f}\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/transmit/arm_motor_enable_disable.py
+++ b/piper_msgs/msg_v1/transmit/arm_motor_enable_disable.py
@@ -4,20 +4,24 @@ from typing_extensions import (
     Literal,
 )
 
+
 class ArmMsgMotorEnableDisableConfig:
-    '''
+    """
     电机使能/失能设置指令
-    '''
-    def __init__(self, 
-                 motor_num:Literal[1, 2, 3, 4, 5, 6, 7, 0xFF]=0xFF,
-                 enable_flag:Literal[0x01, 0x02]=0x01):
+    """
+
+    def __init__(
+        self,
+        motor_num: Literal[1, 2, 3, 4, 5, 6, 7, 0xFF] = 0xFF,
+        enable_flag: Literal[0x01, 0x02] = 0x01,
+    ):
         """
         初始化 ArmMsgMotorEnableDisableConfig 实例。
 
         :Byte 0 motor_num: uint8, 关节电机序号。
                             值域 1-7:
                                 1-6 代表关节驱动器序号
-                                
+
                                 7代表夹爪电机
 
                                 FF代表全部关节电机(包含夹爪)
@@ -26,7 +30,9 @@ class ArmMsgMotorEnableDisableConfig:
                             0x02 : 使能
         """
         if motor_num not in [1, 2, 3, 4, 5, 6, 7, 0xFF]:
-            raise ValueError(f"motor_num 值 {motor_num} 超出范围 [1, 2, 3, 4, 5, 6, 7, 0xFF]")
+            raise ValueError(
+                f"motor_num 值 {motor_num} 超出范围 [1, 2, 3, 4, 5, 6, 7, 0xFF]"
+            )
         if enable_flag not in [0x01, 0x02]:
             raise ValueError(f"enable_flag 值 {enable_flag} 超出范围 [0x01, 0x02]")
         self.motor_num = motor_num
@@ -38,10 +44,12 @@ class ArmMsgMotorEnableDisableConfig:
 
         :return: 格式化的字符串
         """
-        return (f"ArmMsgMotorEnableDisableConfig(\n"
-                f"  motor_num: {self.motor_num },\n"
-                f"  enable_flag: {self.enable_flag },\n"
-                f")")
+        return (
+            f"ArmMsgMotorEnableDisableConfig(\n"
+            f"  motor_num: {self.motor_num },\n"
+            f"  enable_flag: {self.enable_flag },\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/transmit/arm_param_enquiry_and_config.py
+++ b/piper_msgs/msg_v1/transmit/arm_param_enquiry_and_config.py
@@ -3,8 +3,10 @@
 from typing_extensions import (
     Literal,
 )
+
+
 class ArmMsgParamEnquiryAndConfig:
-    '''
+    """
     机械臂参数查询与设置指令
 
     0x477
@@ -19,14 +21,16 @@ class ArmMsgParamEnquiryAndConfig:
     :Byte 4: 设置末端负载, uint8, 0x00 : 空载
                                 0x01 : 半载
                                 0x02 : 满载
-    '''
-    def __init__(self, 
-                 param_enquiry:Literal[0x00, 0x01, 0x02]=0x00, 
-                 param_setting: Literal[0x00, 0x01]=0, 
-                 data_feedback_0x48x: Literal[0x00, 0x01, 0x02]=0x02,
-                 end_load_param_setting_effective: Literal[0x00, 0xAE]=0,
-                 set_end_load: Literal[0x00, 0x01, 0x02, 0x03]=0x03
-                 ):
+    """
+
+    def __init__(
+        self,
+        param_enquiry: Literal[0x00, 0x01, 0x02] = 0x00,
+        param_setting: Literal[0x00, 0x01] = 0,
+        data_feedback_0x48x: Literal[0x00, 0x01, 0x02] = 0x02,
+        end_load_param_setting_effective: Literal[0x00, 0xAE] = 0,
+        set_end_load: Literal[0x00, 0x01, 0x02, 0x03] = 0x03,
+    ):
         """
         初始化 ArmMsgMotorAngleSpdLimitConfig 实例。
 
@@ -46,15 +50,23 @@ class ArmMsgParamEnquiryAndConfig:
                                     0x02 : 满载
         """
         if param_enquiry not in [0x00, 0x01, 0x02]:
-            raise ValueError(f"param_enquiry 值 {param_enquiry} 超出范围 [0x00, 0x01, 0x02]")
+            raise ValueError(
+                f"param_enquiry 值 {param_enquiry} 超出范围 [0x00, 0x01, 0x02]"
+            )
         if param_setting not in [0x00, 0x01]:
             raise ValueError(f"param_setting 值 {param_setting} 超出范围 [0x00, 0x01]")
         if data_feedback_0x48x not in [0x00, 0x01, 0x02]:
-            raise ValueError(f"data_feedback_0x48x 值 {data_feedback_0x48x} 超出范围 [0x00, 0x01, 0x02]")
+            raise ValueError(
+                f"data_feedback_0x48x 值 {data_feedback_0x48x} 超出范围 [0x00, 0x01, 0x02]"
+            )
         if end_load_param_setting_effective not in [0x00, 0xAE]:
-            raise ValueError(f"end_load_param_setting_effective 值 {end_load_param_setting_effective} 超出范围 [0x00, 0xAE]")
+            raise ValueError(
+                f"end_load_param_setting_effective 值 {end_load_param_setting_effective} 超出范围 [0x00, 0xAE]"
+            )
         if set_end_load not in [0x00, 0x01, 0x02, 0x03]:
-            raise ValueError(f"set_end_load 值 {set_end_load} 超出范围 [0x00, 0x01, 0x02, 0x03]")
+            raise ValueError(
+                f"set_end_load 值 {set_end_load} 超出范围 [0x00, 0x01, 0x02, 0x03]"
+            )
         self.param_enquiry = param_enquiry
         self.param_setting = param_setting
         self.data_feedback_0x48x = data_feedback_0x48x
@@ -65,13 +77,15 @@ class ArmMsgParamEnquiryAndConfig:
         """
         返回对象的字符串表示，用于打印。
         """
-        return (f"ArmMsgParamEnquiryAndConfig(\n"
-                f"  param_enquiry: {self.param_enquiry},\n"
-                f"  param_setting: {self.param_setting},\n"
-                f"  data_feedback_0x48x: {self.data_feedback_0x48x},\n"
-                f"  end_load_param_setting_effective: {self.end_load_param_setting_effective},\n"
-                f"  set_end_load: {self.set_end_load}\n"
-                f")")
+        return (
+            f"ArmMsgParamEnquiryAndConfig(\n"
+            f"  param_enquiry: {self.param_enquiry},\n"
+            f"  param_setting: {self.param_setting},\n"
+            f"  data_feedback_0x48x: {self.data_feedback_0x48x},\n"
+            f"  end_load_param_setting_effective: {self.end_load_param_setting_effective},\n"
+            f"  set_end_load: {self.set_end_load}\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/transmit/arm_search_motor_max_angle_spd_acc_limit.py
+++ b/piper_msgs/msg_v1/transmit/arm_search_motor_max_angle_spd_acc_limit.py
@@ -4,8 +4,9 @@ from typing_extensions import (
     Literal,
 )
 
+
 class ArmMsgSearchMotorMaxAngleSpdAccLimit:
-    '''
+    """
     查询电机角度/最大速度/最大加速度限制指令
 
     0x472
@@ -16,10 +17,13 @@ class ArmMsgSearchMotorMaxAngleSpdAccLimit:
     :Byte 1 search_content: uint8, 查询内容。
                         0x01 : 查询电机角度/最大速度
                         0x02 : 查询电机最大加速度限制
-    '''
-    def __init__(self, 
-                 motor_num:Literal[1, 2, 3, 4, 5, 6]=1,
-                 search_content:Literal[0x01, 0x02]=0x01):
+    """
+
+    def __init__(
+        self,
+        motor_num: Literal[1, 2, 3, 4, 5, 6] = 1,
+        search_content: Literal[0x01, 0x02] = 0x01,
+    ):
         """
         查询电机角度/最大速度/最大加速度限制指令
 
@@ -37,7 +41,9 @@ class ArmMsgSearchMotorMaxAngleSpdAccLimit:
         if motor_num not in [1, 2, 3, 4, 5, 6, 7]:
             raise ValueError(f"motor_num 值 {motor_num} 超出范围 [1, 2, 3, 4, 5, 6, 7]")
         if search_content not in [0x01, 0x02]:
-            raise ValueError(f"search_content 值 {search_content} 超出范围 [0x01, 0x02]")
+            raise ValueError(
+                f"search_content 值 {search_content} 超出范围 [0x01, 0x02]"
+            )
         self.motor_num = motor_num
         self.search_content = search_content
 
@@ -47,10 +53,12 @@ class ArmMsgSearchMotorMaxAngleSpdAccLimit:
 
         :return: 格式化的字符串
         """
-        return (f"ArmMsgSearchMotorMaxAngleSpdAccConfig(\n"
-                f"  motor_num: {self.motor_num },\n"
-                f"  search_content: {self.search_content },\n"
-                f")")
+        return (
+            f"ArmMsgSearchMotorMaxAngleSpdAccConfig(\n"
+            f"  motor_num: {self.motor_num },\n"
+            f"  search_content: {self.search_content },\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/piper_msgs/msg_v1/transmit/arm_set_instruction_response.py
+++ b/piper_msgs/msg_v1/transmit/arm_set_instruction_response.py
@@ -4,8 +4,9 @@ from typing_extensions import (
     Literal,
 )
 
+
 class ArmMsgInstructionResponseConfig:
-    '''
+    """
     设置指令应答
 
     0x476
@@ -17,10 +18,13 @@ class ArmMsgInstructionResponseConfig:
                         零点成功设置 : 0x01
                         设置失败/未设置: 0x00
                         仅在关节设置指令--成功设置 N 号电机当前位置为零点时应答 0x01
-    '''
-    def __init__(self,
-                 instruction_index:int=0,
-                 zero_config_success_flag:Literal[0x00, 0x01]=0):
+    """
+
+    def __init__(
+        self,
+        instruction_index: int = 0,
+        zero_config_success_flag: Literal[0x00, 0x01] = 0,
+    ):
         """
         初始化 ArmMsgSearchMotorMaxAngleSpdAccConfig 实例。
 
@@ -37,7 +41,9 @@ class ArmMsgInstructionResponseConfig:
                             仅在关节设置指令--成功设置 N 号电机当前位置为零点时应答 0x01
         """
         if zero_config_success_flag not in [0x00, 0x01]:
-            raise ValueError(f"zero_config_success_flag 值 {zero_config_success_flag} 超出范围 [0x01, 0x02]")
+            raise ValueError(
+                f"zero_config_success_flag 值 {zero_config_success_flag} 超出范围 [0x01, 0x02]"
+            )
         self.instruction_index = instruction_index
         self.zero_config_success_flag = zero_config_success_flag
 
@@ -47,10 +53,12 @@ class ArmMsgInstructionResponseConfig:
 
         :return: 格式化的字符串
         """
-        return (f"ArmMsgInstructionResponseConfig(\n"
-                f"  instruction_index: {self.instruction_index },\n"
-                f"  zero_config_success_flag: {self.zero_config_success_flag },\n"
-                f")")
+        return (
+            f"ArmMsgInstructionResponseConfig(\n"
+            f"  instruction_index: {self.instruction_index },\n"
+            f"  zero_config_success_flag: {self.zero_config_success_flag },\n"
+            f")"
+        )
 
     def __repr__(self):
         """

--- a/protocol/__init__.py
+++ b/protocol/__init__.py
@@ -1,8 +1,3 @@
-
 from .protocol_v1 import *
 
-__all__ = [
-    'C_PiperParserBase',
-    'C_PiperParserV1'
-]
-
+__all__ = ["C_PiperParserBase", "C_PiperParserV1"]

--- a/protocol/piper_protocol_base.py
+++ b/protocol/piper_protocol_base.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
-#机械臂协议解析基类
+# 机械臂协议解析基类
 
 from abc import ABC, abstractmethod
 from enum import Enum, auto
@@ -9,53 +9,58 @@ from typing_extensions import (
     LiteralString,
 )
 
+
 class C_PiperParserBase(ABC):
-    '''
+    """
     Piper机械臂数据解析基类
-    '''
+    """
+
     class ProtocolVersion(Enum):
-        '''
+        """
         协议版本枚举,需要在派生类中指定
-        '''
+        """
+
         ARM_PROTOCOL_UNKNOWN = auto()
         ARM_PROROCOL_V1 = auto()
+
         def __str__(self):
             return f"{self.name} (0x{self.value:X})"
+
         def __repr__(self):
             return f"{self.name}: 0x{self.value:X}"
-    
+
     def __init__(self) -> None:
         super().__init__()
-    
+
     @abstractmethod
     def DecodeMessage(self):
-        '''
+        """
         解码消息,将can数据帧转为设定的类型
-        '''
+        """
         pass
-    
+
     @abstractmethod
     def EncodeMessage(self):
-        '''
+        """
         将消息转为can数据帧
-        
+
         只将输入数据转换为can数据的id和data, 没有为can message赋值channel、dlc、is_extended_id
-        '''
+        """
         pass
 
     @abstractmethod
     def GetParserProtocolVersion(self):
-        '''
+        """
         获取当前协议版本
-        '''
+        """
         pass
-    
-    def ConvertToNegative_8bit(self, value: int, signed:bool=True) -> int:
-        '''
+
+    def ConvertToNegative_8bit(self, value: int, signed: bool = True) -> int:
+        """
         将输入的整数转换为8位整数。
         如果 signed 为 True,则转换为32位有符号整数。[-128, 127]
         如果 signed 为 False,则转换为32位无符号整数。[0, 255]
-        '''
+        """
         # 范围检查
         if not (0 <= value <= 255):
             print("转换成8bit整数时出错:输入值超出 8 位无符号整数范围: [0, 255]")
@@ -67,10 +72,10 @@ class C_PiperParserBase(ABC):
         return value
 
     def ConvertToNegative_int8_t(value: int) -> int:
-        '''
+        """
         将输入的整数转换为8位有符号整数。
         范围: [-128, 127]
-        '''
+        """
         # 范围检查
         if not (0 <= value <= 255):
             print("转换成8bit有符号整数时出错: 输入值超出范围: [0, 255]")
@@ -81,10 +86,10 @@ class C_PiperParserBase(ABC):
         return value
 
     def ConvertToNegative_uint8_t(value: int) -> int:
-        '''
+        """
         将输入的整数转换为8位无符号整数。
         范围: [0, 255]
-        '''
+        """
         # 范围检查
         if not (0 <= value <= 255):
             print("转换成8bit无符号整数时出错: 输入值超出范围: [0, 255]")
@@ -92,12 +97,12 @@ class C_PiperParserBase(ABC):
         value &= 0xFF  # 将 value 转换成 8 位无符号整数
         return value
 
-    def ConvertToNegative_16bit(self, value: int, signed:bool=True) -> int:
-        '''
+    def ConvertToNegative_16bit(self, value: int, signed: bool = True) -> int:
+        """
         将输入的整数转换为16位整数。
         如果 signed 为 True,则转换为32位有符号整数。[-32768, 32767]
         如果 signed 为 False,则转换为32位无符号整数。[0, 65535]
-        '''
+        """
         # 范围检查
         if not (0 <= value <= 65535):
             print("转换成16bit整数时出错:输入值超出 16 位无符号整数范围: [0, 65535]")
@@ -107,12 +112,12 @@ class C_PiperParserBase(ABC):
             if value & 0x8000:  # 检查符号位
                 value -= 0x10000  # 如果符号位为 1，表示负数，需要减去 2^16
         return value
-    
+
     def ConvertToNegative_int16_t(value: int) -> int:
-        '''
+        """
         将输入的整数转换为16位有符号整数。
         范围: [-32768, 32767]
-        '''
+        """
         # 范围检查
         if not (0 <= value <= 65535):
             print("转换成8bit有符号整数时出错: 输入值超出范围: [0, 65535]")
@@ -123,10 +128,10 @@ class C_PiperParserBase(ABC):
         return value
 
     def ConvertToNegative_uint16_t(value: int) -> int:
-        '''
+        """
         将输入的整数转换为16位无符号整数。
         范围: [0, 65535]
-        '''
+        """
         # 范围检查
         if not (0 <= value <= 65535):
             print("转换成8bit无符号整数时出错: 输入值超出范围: [0, 65535]")
@@ -134,27 +139,29 @@ class C_PiperParserBase(ABC):
         value &= 0xFFFF  # 将 value 转换成 8 位无符号整数
         return value
 
-    def ConvertToNegative_32bit(self, value:int, signed:bool=True):
-        '''
+    def ConvertToNegative_32bit(self, value: int, signed: bool = True):
+        """
         将输入的整数转换为32位整数。
         如果 signed 为 True,则转换为32位有符号整数。
         如果 signed 为 False,则转换为32位无符号整数。
-        '''
+        """
         # 范围检查
         if not (0 <= value <= 4294967295):
-            print("转换成32bit整数时出错:输入值超出 32 位无符号整数范围: [0, 4294967295]")
+            print(
+                "转换成32bit整数时出错:输入值超出 32 位无符号整数范围: [0, 4294967295]"
+            )
         # 转换成 32 位无符号整数
         value &= 0xFFFFFFFF  # 将 value 转换成 32 位无符号整数
         if signed:
             if value & 0x80000000:  # 检查符号位
                 value -= 0x100000000  # 如果符号位为 1，表示负数，需要减去 2^32
         return value
-    
+
     def ConvertToNegative_int32_t(value: int) -> int:
-        '''
+        """
         将输入的整数转换为32位有符号整数。
         范围: [-2147483648, 2147483647]
-        '''
+        """
         # 范围检查
         if not (0 <= value <= 4294967295):
             print("转换成8bit有符号整数时出错: 输入值超出范围: [0, 4294967295]")
@@ -165,10 +172,10 @@ class C_PiperParserBase(ABC):
         return value
 
     def ConvertToNegative_uint32_t(value: int) -> int:
-        '''
+        """
         将输入的整数转换为32位无符号整数。
         范围: [0, 4294967295]
-        '''
+        """
         # 范围检查
         if not (0 <= value <= 4294967295):
             print("转换成8bit无符号整数时出错: 输入值超出范围: [0, 4294967295]")
@@ -177,25 +184,29 @@ class C_PiperParserBase(ABC):
         return value
 
     def ConvertToList_8bit(self, value: int, signed: bool = True):
-        '''
+        """
         将输入的整数转换为8位整数列表。
         根据signed参数判断是否将其视为带符号整数。
         超出范围时给出提示。
-        '''
+        """
         if signed:
             if not -128 <= value <= 127:
-                raise ValueError(f"输入的值 {value} 超出了8位有符号整数的范围 [-128, 127].")
+                raise ValueError(
+                    f"输入的值 {value} 超出了8位有符号整数的范围 [-128, 127]."
+                )
             if value < 0:
                 value = (value + 0x100) & 0xFF  # 转换为8位表示
             else:
                 value &= 0xFF
         else:
             if not 0 <= value <= 255:
-                raise ValueError(f"输入的值 {value} 超出了8位无符号整数的范围 [0, 255].")
+                raise ValueError(
+                    f"输入的值 {value} 超出了8位无符号整数的范围 [0, 255]."
+                )
             value &= 0xFF
-        
+
         return [value]
-    
+
     def ConvertToList_int8_t(self, value: int):
         if not -128 <= value <= 127:
             raise ValueError(f"输入的值 {value} 超出了8位有符号整数的范围 [-128, 127].")
@@ -204,7 +215,7 @@ class C_PiperParserBase(ABC):
         else:
             value &= 0xFF
         return [value]
-    
+
     def ConvertToList_uint8_t(self, value: int):
         if not 0 <= value <= 255:
             raise ValueError(f"输入的值 {value} 超出了8位无符号整数的范围 [0, 255].")
@@ -212,21 +223,25 @@ class C_PiperParserBase(ABC):
         return [value]
 
     def ConvertToList_16bit(self, value: int, signed: bool = True):
-        '''
+        """
         将输入的整数转换为16位整数列表。
         根据signed参数判断是否将其视为带符号整数。
         超出范围时给出提示。
-        '''
+        """
         if signed:
             if not -32768 <= value <= 32767:
-                raise ValueError(f"输入的值 {value} 超出了16位有符号整数的范围 [-32768, 32767].")
+                raise ValueError(
+                    f"输入的值 {value} 超出了16位有符号整数的范围 [-32768, 32767]."
+                )
             if value < 0:
                 value = (value + 0x10000) & 0xFFFF  # 转换为16位表示
             else:
                 value &= 0xFFFF
         else:
             if not 0 <= value <= 65535:
-                raise ValueError(f"输入的值 {value} 超出了16位无符号整数的范围 [0, 65535].")
+                raise ValueError(
+                    f"输入的值 {value} 超出了16位无符号整数的范围 [0, 65535]."
+                )
             value &= 0xFFFF
 
         # 将结果拆分为两个uint8值
@@ -237,7 +252,9 @@ class C_PiperParserBase(ABC):
 
     def ConvertToList_int16_t(self, value: int):
         if not -32768 <= value <= 32767:
-            raise ValueError(f"输入的值 {value} 超出了16位有符号整数的范围 [-32768, 32767].")
+            raise ValueError(
+                f"输入的值 {value} 超出了16位有符号整数的范围 [-32768, 32767]."
+            )
         if value < 0:
             value = (value + 0x10000) & 0xFFFF  # 转换为16位表示
         else:
@@ -246,7 +263,7 @@ class C_PiperParserBase(ABC):
         high_byte = (value >> 8) & 0xFF
         low_byte = value & 0xFF
         return [high_byte, low_byte]
-    
+
     def ConvertToList_uint16_t(self, value: int):
         if not 0 <= value <= 65535:
             raise ValueError(f"输入的值 {value} 超出了16位无符号整数的范围 [0, 65535].")
@@ -257,21 +274,25 @@ class C_PiperParserBase(ABC):
         return [high_byte, low_byte]
 
     def ConvertToList_32bit(self, value: int, signed: bool = True):
-        '''
+        """
         将输入的整数转换为32位整数列表。
         根据signed参数判断是否将其视为带符号整数。
         超出范围时给出提示。
-        '''
+        """
         if signed:
             if not -2147483648 <= value <= 2147483647:
-                raise ValueError(f"输入的值 {value} 超出了32位有符号整数的范围 [-2147483648, 2147483647].")
+                raise ValueError(
+                    f"输入的值 {value} 超出了32位有符号整数的范围 [-2147483648, 2147483647]."
+                )
             if value < 0:
                 value = (value + 0x100000000) & 0xFFFFFFFF  # 转换为32位表示
             else:
                 value &= 0xFFFFFFFF
         else:
             if not 0 <= value <= 4294967295:
-                raise ValueError(f"输入的值 {value} 超出了32位无符号整数的范围 [0, 4294967295].")
+                raise ValueError(
+                    f"输入的值 {value} 超出了32位无符号整数的范围 [0, 4294967295]."
+                )
             value &= 0xFFFFFFFF
 
         # 将结果拆分为四个uint8值
@@ -284,7 +305,9 @@ class C_PiperParserBase(ABC):
 
     def ConvertToList_int32_t(self, value: int):
         if not -2147483648 <= value <= 2147483647:
-            raise ValueError(f"输入的值 {value} 超出了32位有符号整数的范围 [-2147483648, 2147483647].")
+            raise ValueError(
+                f"输入的值 {value} 超出了32位有符号整数的范围 [-2147483648, 2147483647]."
+            )
         if value < 0:
             value = (value + 0x100000000) & 0xFFFFFFFF  # 转换为32位表示
         else:
@@ -295,10 +318,12 @@ class C_PiperParserBase(ABC):
         byte_1 = (value >> 8) & 0xFF
         byte_0 = value & 0xFF
         return [byte_3, byte_2, byte_1, byte_0]
-    
+
     def ConvertToList_uint32_t(self, value: int):
         if not 0 <= value <= 4294967295:
-            raise ValueError(f"输入的值 {value} 超出了32位无符号整数的范围 [0, 4294967295].")
+            raise ValueError(
+                f"输入的值 {value} 超出了32位无符号整数的范围 [0, 4294967295]."
+            )
         value &= 0xFFFFFFFF
         # 将结果拆分为四个uint8值
         byte_3 = (value >> 24) & 0xFF
@@ -307,8 +332,14 @@ class C_PiperParserBase(ABC):
         byte_0 = value & 0xFF
         return [byte_3, byte_2, byte_1, byte_0]
 
-    def ConvertBytesToInt(self, bytes:bytearray, first_index:int, second_index:int, byteorder:Literal["little", "big"]='big'):
-        '''
+    def ConvertBytesToInt(
+        self,
+        bytes: bytearray,
+        first_index: int,
+        second_index: int,
+        byteorder: Literal["little", "big"] = "big",
+    ):
+        """
         将字节串转换为int类型,默认为大端对齐
-        '''
+        """
         return int.from_bytes(bytes[first_index:second_index], byteorder=byteorder)

--- a/protocol/protocol_v1/__init__.py
+++ b/protocol/protocol_v1/__init__.py
@@ -3,7 +3,4 @@
 from ..piper_protocol_base import C_PiperParserBase
 from .piper_protocol_v1 import C_PiperParserV1
 
-__all__ = [
-    "C_PiperParserBase",
-    "C_PiperParserV1"
-]
+__all__ = ["C_PiperParserBase", "C_PiperParserV1"]

--- a/protocol/protocol_v1/piper_protocol_v1.py
+++ b/protocol/protocol_v1/piper_protocol_v1.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
-#机械臂协议V1版本，为方便后续修改协议升级，继承自base
+# 机械臂协议V1版本，为方便后续修改协议升级，继承自base
 
 from abc import ABC, abstractmethod
 import time
@@ -16,31 +16,34 @@ from typing import (
 # import sys,os
 # sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
 from ..piper_protocol_base import C_PiperParserBase
+
 # from ...protocol.piper_protocol_base import C_PiperParserBase
 from ...piper_msgs.msg_v1 import (
-    ArmMsgType, 
-    PiperMessage, 
-    ArmMsgStatus, 
-    ArmMsgJointFeedBack, 
-    ArmMsgGripperFeedBack, 
+    ArmMsgType,
+    PiperMessage,
+    ArmMsgStatus,
+    ArmMsgJointFeedBack,
+    ArmMsgGripperFeedBack,
     CanIDPiper,
-    ArmMessageMapping
+    ArmMessageMapping,
 )
 
+
 class C_PiperParserV1(C_PiperParserBase):
-    '''
+    """
     Piper机械臂解析数据类V1版本
-    '''
+    """
+
     def __init__(self) -> None:
         pass
 
     def GetParserProtocolVersion(self):
-        '''
+        """
         获取当前协议版本,当前为V1
-        '''
+        """
         return self.ProtocolVersion.ARM_PROROCOL_V1
 
-    def DecodeMessage(self, rx_can_frame: Optional[can.Message], msg:PiperMessage):
+    def DecodeMessage(self, rx_can_frame: Optional[can.Message], msg: PiperMessage):
         """解码消息,将can数据帧转为设定的类型
 
         Args:
@@ -53,198 +56,428 @@ class C_PiperParserV1(C_PiperParserBase):
 
                 can消息的id若不存在, 反馈False
         """
-        ret:bool = True
-        can_id:int = rx_can_frame.arbitration_id
-        can_data:bytearray = rx_can_frame.data
+        ret: bool = True
+        can_id: int = rx_can_frame.arbitration_id
+        can_data: bytearray = rx_can_frame.data
         # 机械臂状态反馈
-        if(can_id == CanIDPiper.ARM_STATUS_FEEDBACK.value):
+        if can_id == CanIDPiper.ARM_STATUS_FEEDBACK.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_status_msgs.ctrl_mode = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,0,1),False)
-            msg.arm_status_msgs.arm_status = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,1,2),False)
-            msg.arm_status_msgs.mode_feed = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,2,3),False)
-            msg.arm_status_msgs.teach_status = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,3,4),False)
-            msg.arm_status_msgs.motion_status = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,4,5),False)
-            msg.arm_status_msgs.trajectory_num = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,5,6),False)
-            msg.arm_status_msgs.err_code = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,6,8),False)
+            msg.arm_status_msgs.ctrl_mode = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 0, 1), False
+            )
+            msg.arm_status_msgs.arm_status = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 1, 2), False
+            )
+            msg.arm_status_msgs.mode_feed = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 2, 3), False
+            )
+            msg.arm_status_msgs.teach_status = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 3, 4), False
+            )
+            msg.arm_status_msgs.motion_status = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 4, 5), False
+            )
+            msg.arm_status_msgs.trajectory_num = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 5, 6), False
+            )
+            msg.arm_status_msgs.err_code = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 6, 8), False
+            )
         # 机械臂末端位姿
-        elif(can_id == CanIDPiper.ARM_END_POSE_FEEDBACK_1.value):
+        elif can_id == CanIDPiper.ARM_END_POSE_FEEDBACK_1.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_end_pose.X_axis = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,0,4))
-            msg.arm_end_pose.Y_axis = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
-        elif(can_id == CanIDPiper.ARM_END_POSE_FEEDBACK_2.value):
+            msg.arm_end_pose.X_axis = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 0, 4)
+            )
+            msg.arm_end_pose.Y_axis = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
+        elif can_id == CanIDPiper.ARM_END_POSE_FEEDBACK_2.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_end_pose.Z_axis = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,0,4))
-            msg.arm_end_pose.RX_axis = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
-        elif(can_id == CanIDPiper.ARM_END_POSE_FEEDBACK_3.value):
+            msg.arm_end_pose.Z_axis = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 0, 4)
+            )
+            msg.arm_end_pose.RX_axis = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
+        elif can_id == CanIDPiper.ARM_END_POSE_FEEDBACK_3.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_end_pose.RY_axis = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,0,4))
-            msg.arm_end_pose.RZ_axis = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
+            msg.arm_end_pose.RY_axis = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 0, 4)
+            )
+            msg.arm_end_pose.RZ_axis = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
         # 关节角度反馈
-        elif(can_id == CanIDPiper.ARM_JOINT_FEEDBACK_12.value):
+        elif can_id == CanIDPiper.ARM_JOINT_FEEDBACK_12.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_joint_feedback.joint_1 = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,0,4))
-            msg.arm_joint_feedback.joint_2 = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
-        elif(can_id == CanIDPiper.ARM_JOINT_FEEDBACK_34.value):
+            msg.arm_joint_feedback.joint_1 = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 0, 4)
+            )
+            msg.arm_joint_feedback.joint_2 = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
+        elif can_id == CanIDPiper.ARM_JOINT_FEEDBACK_34.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_joint_feedback.joint_3 = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,0,4))
-            msg.arm_joint_feedback.joint_4 = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
-        elif(can_id == CanIDPiper.ARM_JOINT_FEEDBACK_56.value):
+            msg.arm_joint_feedback.joint_3 = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 0, 4)
+            )
+            msg.arm_joint_feedback.joint_4 = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
+        elif can_id == CanIDPiper.ARM_JOINT_FEEDBACK_56.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_joint_feedback.joint_5 = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,0,4))
-            msg.arm_joint_feedback.joint_6 = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
+            msg.arm_joint_feedback.joint_5 = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 0, 4)
+            )
+            msg.arm_joint_feedback.joint_6 = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
         # 夹爪反馈
-        elif(can_id == CanIDPiper.ARM_GRIPPER_FEEDBACK.value):
+        elif can_id == CanIDPiper.ARM_GRIPPER_FEEDBACK.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.gripper_feedback.grippers_angle = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,0,4))
-            msg.gripper_feedback.grippers_effort = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,4,6))
-            msg.gripper_feedback.status_code = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,6,7),False)
+            msg.gripper_feedback.grippers_angle = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 0, 4)
+            )
+            msg.gripper_feedback.grippers_effort = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 4, 6)
+            )
+            msg.gripper_feedback.status_code = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 6, 7), False
+            )
             # print(rx_can_frame)
         # 驱动器信息高速反馈
-        elif(can_id == CanIDPiper.ARM_INFO_HIGH_SPD_FEEDBACK_1.value):
+        elif can_id == CanIDPiper.ARM_INFO_HIGH_SPD_FEEDBACK_1.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
             msg.arm_high_spd_feedback_1.can_id = can_id
-            msg.arm_high_spd_feedback_1.motor_speed = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2))
-            msg.arm_high_spd_feedback_1.current = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4),False)
-            msg.arm_high_spd_feedback_1.pos = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
-        elif(can_id == CanIDPiper.ARM_INFO_HIGH_SPD_FEEDBACK_2.value):
+            msg.arm_high_spd_feedback_1.motor_speed = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 0, 2)
+            )
+            msg.arm_high_spd_feedback_1.current = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 2, 4), False
+            )
+            msg.arm_high_spd_feedback_1.pos = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
+        elif can_id == CanIDPiper.ARM_INFO_HIGH_SPD_FEEDBACK_2.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
             msg.arm_high_spd_feedback_2.can_id = can_id
-            msg.arm_high_spd_feedback_2.motor_speed = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2))
-            msg.arm_high_spd_feedback_2.current = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4),False)
-            msg.arm_high_spd_feedback_3.pos = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
-        elif(can_id == CanIDPiper.ARM_INFO_HIGH_SPD_FEEDBACK_3.value):
+            msg.arm_high_spd_feedback_2.motor_speed = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 0, 2)
+            )
+            msg.arm_high_spd_feedback_2.current = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 2, 4), False
+            )
+            msg.arm_high_spd_feedback_3.pos = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
+        elif can_id == CanIDPiper.ARM_INFO_HIGH_SPD_FEEDBACK_3.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
             msg.arm_high_spd_feedback_3.can_id = can_id
-            msg.arm_high_spd_feedback_3.motor_speed = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2))
-            msg.arm_high_spd_feedback_3.current = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4),False)
-            msg.arm_high_spd_feedback_3.pos = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
-        elif(can_id == CanIDPiper.ARM_INFO_HIGH_SPD_FEEDBACK_4.value):
+            msg.arm_high_spd_feedback_3.motor_speed = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 0, 2)
+            )
+            msg.arm_high_spd_feedback_3.current = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 2, 4), False
+            )
+            msg.arm_high_spd_feedback_3.pos = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
+        elif can_id == CanIDPiper.ARM_INFO_HIGH_SPD_FEEDBACK_4.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
             msg.arm_high_spd_feedback_4.can_id = can_id
-            msg.arm_high_spd_feedback_4.motor_speed = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2))
-            msg.arm_high_spd_feedback_4.current = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4),False)
-            msg.arm_high_spd_feedback_4.pos = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
-        elif(can_id == CanIDPiper.ARM_INFO_HIGH_SPD_FEEDBACK_5.value):
+            msg.arm_high_spd_feedback_4.motor_speed = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 0, 2)
+            )
+            msg.arm_high_spd_feedback_4.current = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 2, 4), False
+            )
+            msg.arm_high_spd_feedback_4.pos = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
+        elif can_id == CanIDPiper.ARM_INFO_HIGH_SPD_FEEDBACK_5.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
             msg.arm_high_spd_feedback_5.can_id = can_id
-            msg.arm_high_spd_feedback_5.motor_speed = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2))
-            msg.arm_high_spd_feedback_5.current = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4),False)
-            msg.arm_high_spd_feedback_5.pos = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
-        elif(can_id == CanIDPiper.ARM_INFO_HIGH_SPD_FEEDBACK_6.value):
+            msg.arm_high_spd_feedback_5.motor_speed = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 0, 2)
+            )
+            msg.arm_high_spd_feedback_5.current = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 2, 4), False
+            )
+            msg.arm_high_spd_feedback_5.pos = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
+        elif can_id == CanIDPiper.ARM_INFO_HIGH_SPD_FEEDBACK_6.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
             msg.arm_high_spd_feedback_6.can_id = can_id
-            msg.arm_high_spd_feedback_6.motor_speed = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2))
-            msg.arm_high_spd_feedback_6.current = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4),False)
-            msg.arm_high_spd_feedback_6.pos = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
+            msg.arm_high_spd_feedback_6.motor_speed = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 0, 2)
+            )
+            msg.arm_high_spd_feedback_6.current = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 2, 4), False
+            )
+            msg.arm_high_spd_feedback_6.pos = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
             # print(msg.arm_high_spd_feedback_6)
         # 驱动器信息低速反馈
-        elif(can_id == CanIDPiper.ARM_INFO_LOW_SPD_FEEDBACK_1.value):
+        elif can_id == CanIDPiper.ARM_INFO_LOW_SPD_FEEDBACK_1.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
             msg.arm_low_spd_feedback_1.can_id = can_id
-            msg.arm_low_spd_feedback_1.vol = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2),False)
-            msg.arm_low_spd_feedback_1.foc_temp = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4))
-            msg.arm_low_spd_feedback_1.motor_temp = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,4,5))
-            msg.arm_low_spd_feedback_1.foc_status_code = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,5,6),False)
-            msg.arm_low_spd_feedback_1.bus_current = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,6,8),False)
+            msg.arm_low_spd_feedback_1.vol = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 0, 2), False
+            )
+            msg.arm_low_spd_feedback_1.foc_temp = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 2, 4)
+            )
+            msg.arm_low_spd_feedback_1.motor_temp = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 4, 5)
+            )
+            msg.arm_low_spd_feedback_1.foc_status_code = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 5, 6), False
+            )
+            msg.arm_low_spd_feedback_1.bus_current = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 6, 8), False
+            )
             # print(rx_can_frame)
             # print(msg.arm_low_spd_feedback_1)
-        elif(can_id == CanIDPiper.ARM_INFO_LOW_SPD_FEEDBACK_2.value):
+        elif can_id == CanIDPiper.ARM_INFO_LOW_SPD_FEEDBACK_2.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
             msg.arm_low_spd_feedback_2.can_id = can_id
-            msg.arm_low_spd_feedback_2.vol = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2),False)
-            msg.arm_low_spd_feedback_2.foc_temp = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4))
-            msg.arm_low_spd_feedback_2.motor_temp = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,4,5))
-            msg.arm_low_spd_feedback_2.foc_status_code = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,5,6),False)
-            msg.arm_low_spd_feedback_2.bus_current = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,6,8),False)
-        elif(can_id == CanIDPiper.ARM_INFO_LOW_SPD_FEEDBACK_3.value):
+            msg.arm_low_spd_feedback_2.vol = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 0, 2), False
+            )
+            msg.arm_low_spd_feedback_2.foc_temp = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 2, 4)
+            )
+            msg.arm_low_spd_feedback_2.motor_temp = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 4, 5)
+            )
+            msg.arm_low_spd_feedback_2.foc_status_code = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 5, 6), False
+            )
+            msg.arm_low_spd_feedback_2.bus_current = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 6, 8), False
+            )
+        elif can_id == CanIDPiper.ARM_INFO_LOW_SPD_FEEDBACK_3.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
             msg.arm_low_spd_feedback_3.can_id = can_id
-            msg.arm_low_spd_feedback_3.vol = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2),False)
-            msg.arm_low_spd_feedback_3.foc_temp = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4))
-            msg.arm_low_spd_feedback_3.motor_temp = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,4,5))
-            msg.arm_low_spd_feedback_3.foc_status_code = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,5,6),False)
-            msg.arm_low_spd_feedback_3.bus_current = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,6,8),False)
-        elif(can_id == CanIDPiper.ARM_INFO_LOW_SPD_FEEDBACK_4.value):
+            msg.arm_low_spd_feedback_3.vol = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 0, 2), False
+            )
+            msg.arm_low_spd_feedback_3.foc_temp = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 2, 4)
+            )
+            msg.arm_low_spd_feedback_3.motor_temp = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 4, 5)
+            )
+            msg.arm_low_spd_feedback_3.foc_status_code = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 5, 6), False
+            )
+            msg.arm_low_spd_feedback_3.bus_current = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 6, 8), False
+            )
+        elif can_id == CanIDPiper.ARM_INFO_LOW_SPD_FEEDBACK_4.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
             msg.arm_low_spd_feedback_4.can_id = can_id
-            msg.arm_low_spd_feedback_4.vol = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2),False)
-            msg.arm_low_spd_feedback_4.foc_temp = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4))
-            msg.arm_low_spd_feedback_4.motor_temp = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,4,5))
-            msg.arm_low_spd_feedback_4.foc_status_code = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,5,6),False)
-            msg.arm_low_spd_feedback_4.bus_current = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,6,8),False)
-        elif(can_id == CanIDPiper.ARM_INFO_LOW_SPD_FEEDBACK_5.value):
+            msg.arm_low_spd_feedback_4.vol = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 0, 2), False
+            )
+            msg.arm_low_spd_feedback_4.foc_temp = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 2, 4)
+            )
+            msg.arm_low_spd_feedback_4.motor_temp = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 4, 5)
+            )
+            msg.arm_low_spd_feedback_4.foc_status_code = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 5, 6), False
+            )
+            msg.arm_low_spd_feedback_4.bus_current = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 6, 8), False
+            )
+        elif can_id == CanIDPiper.ARM_INFO_LOW_SPD_FEEDBACK_5.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
             msg.arm_low_spd_feedback_5.can_id = can_id
-            msg.arm_low_spd_feedback_5.vol = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2),False)
-            msg.arm_low_spd_feedback_5.foc_temp = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4))
-            msg.arm_low_spd_feedback_5.motor_temp = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,4,5))
-            msg.arm_low_spd_feedback_5.foc_status_code = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,5,6),False)
-            msg.arm_low_spd_feedback_5.bus_current = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,6,8),False)
-        elif(can_id == CanIDPiper.ARM_INFO_LOW_SPD_FEEDBACK_6.value):
+            msg.arm_low_spd_feedback_5.vol = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 0, 2), False
+            )
+            msg.arm_low_spd_feedback_5.foc_temp = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 2, 4)
+            )
+            msg.arm_low_spd_feedback_5.motor_temp = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 4, 5)
+            )
+            msg.arm_low_spd_feedback_5.foc_status_code = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 5, 6), False
+            )
+            msg.arm_low_spd_feedback_5.bus_current = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 6, 8), False
+            )
+        elif can_id == CanIDPiper.ARM_INFO_LOW_SPD_FEEDBACK_6.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
             msg.arm_low_spd_feedback_6.can_id = can_id
-            msg.arm_low_spd_feedback_6.vol = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2),False)
-            msg.arm_low_spd_feedback_6.foc_temp = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4))
-            msg.arm_low_spd_feedback_6.motor_temp = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,4,5))
-            msg.arm_low_spd_feedback_6.foc_status_code = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,5,6),False)
-            msg.arm_low_spd_feedback_6.bus_current = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,6,8),False)
-        elif(can_id == CanIDPiper.ARM_FEEDBACK_CURRENT_MOTOR_ANGLE_LIMIT_MAX_SPD.value):
+            msg.arm_low_spd_feedback_6.vol = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 0, 2), False
+            )
+            msg.arm_low_spd_feedback_6.foc_temp = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 2, 4)
+            )
+            msg.arm_low_spd_feedback_6.motor_temp = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 4, 5)
+            )
+            msg.arm_low_spd_feedback_6.foc_status_code = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 5, 6), False
+            )
+            msg.arm_low_spd_feedback_6.bus_current = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 6, 8), False
+            )
+        elif can_id == CanIDPiper.ARM_FEEDBACK_CURRENT_MOTOR_ANGLE_LIMIT_MAX_SPD.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,0,1),False)
-            msg.arm_feedback_current_motor_angle_limit_max_spd.max_angle_limit = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,1,3))
-            msg.arm_feedback_current_motor_angle_limit_max_spd.min_angle_limit = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,3,5))
-            msg.arm_feedback_current_motor_angle_limit_max_spd.max_jonit_spd = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,5,7),False)
-        elif(can_id == CanIDPiper.ARM_FEEDBACK_CURRENT_END_VEL_ACC_PARAM.value):
+            msg.arm_feedback_current_motor_angle_limit_max_spd.motor_num = (
+                self.ConvertToNegative_8bit(
+                    self.ConvertBytesToInt(can_data, 0, 1), False
+                )
+            )
+            msg.arm_feedback_current_motor_angle_limit_max_spd.max_angle_limit = (
+                self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data, 1, 3))
+            )
+            msg.arm_feedback_current_motor_angle_limit_max_spd.min_angle_limit = (
+                self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data, 3, 5))
+            )
+            msg.arm_feedback_current_motor_angle_limit_max_spd.max_jonit_spd = (
+                self.ConvertToNegative_16bit(
+                    self.ConvertBytesToInt(can_data, 5, 7), False
+                )
+            )
+        elif can_id == CanIDPiper.ARM_FEEDBACK_CURRENT_END_VEL_ACC_PARAM.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_feedback_current_end_vel_acc_param.end_max_linear_vel = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,0,2),False)
-            msg.arm_feedback_current_end_vel_acc_param.end_max_angular_vel = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,2,4),False)
-            msg.arm_feedback_current_end_vel_acc_param.end_max_linear_acc = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,4,6),False)
-            msg.arm_feedback_current_end_vel_acc_param.end_max_angular_acc = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,6,8),False)
-        elif(can_id == CanIDPiper.ARM_CRASH_PROTECTION_RATING_FEEDBACK.value):
+            msg.arm_feedback_current_end_vel_acc_param.end_max_linear_vel = (
+                self.ConvertToNegative_16bit(
+                    self.ConvertBytesToInt(can_data, 0, 2), False
+                )
+            )
+            msg.arm_feedback_current_end_vel_acc_param.end_max_angular_vel = (
+                self.ConvertToNegative_16bit(
+                    self.ConvertBytesToInt(can_data, 2, 4), False
+                )
+            )
+            msg.arm_feedback_current_end_vel_acc_param.end_max_linear_acc = (
+                self.ConvertToNegative_16bit(
+                    self.ConvertBytesToInt(can_data, 4, 6), False
+                )
+            )
+            msg.arm_feedback_current_end_vel_acc_param.end_max_angular_acc = (
+                self.ConvertToNegative_16bit(
+                    self.ConvertBytesToInt(can_data, 6, 8), False
+                )
+            )
+        elif can_id == CanIDPiper.ARM_CRASH_PROTECTION_RATING_FEEDBACK.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_crash_protection_rating_feedback.jonit_1_protection_level = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,0,1),False)
-            msg.arm_crash_protection_rating_feedback.jonit_2_protection_level = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,1,2),False)
-            msg.arm_crash_protection_rating_feedback.jonit_3_protection_level = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,2,3),False)
-            msg.arm_crash_protection_rating_feedback.jonit_4_protection_level = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,3,4),False)
-            msg.arm_crash_protection_rating_feedback.jonit_5_protection_level = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,4,5),False)
-            msg.arm_crash_protection_rating_feedback.jonit_6_protection_level = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,5,6),False)
-        elif(can_id == CanIDPiper.ARM_FEEDBACK_CURRENT_MOTOR_MAX_ACC_LIMIT.value):
+            msg.arm_crash_protection_rating_feedback.jonit_1_protection_level = (
+                self.ConvertToNegative_8bit(
+                    self.ConvertBytesToInt(can_data, 0, 1), False
+                )
+            )
+            msg.arm_crash_protection_rating_feedback.jonit_2_protection_level = (
+                self.ConvertToNegative_8bit(
+                    self.ConvertBytesToInt(can_data, 1, 2), False
+                )
+            )
+            msg.arm_crash_protection_rating_feedback.jonit_3_protection_level = (
+                self.ConvertToNegative_8bit(
+                    self.ConvertBytesToInt(can_data, 2, 3), False
+                )
+            )
+            msg.arm_crash_protection_rating_feedback.jonit_4_protection_level = (
+                self.ConvertToNegative_8bit(
+                    self.ConvertBytesToInt(can_data, 3, 4), False
+                )
+            )
+            msg.arm_crash_protection_rating_feedback.jonit_5_protection_level = (
+                self.ConvertToNegative_8bit(
+                    self.ConvertBytesToInt(can_data, 4, 5), False
+                )
+            )
+            msg.arm_crash_protection_rating_feedback.jonit_6_protection_level = (
+                self.ConvertToNegative_8bit(
+                    self.ConvertBytesToInt(can_data, 5, 6), False
+                )
+            )
+        elif can_id == CanIDPiper.ARM_FEEDBACK_CURRENT_MOTOR_MAX_ACC_LIMIT.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,0,1),False)
-            msg.arm_feedback_current_motor_max_acc_limit.max_joint_acc = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,1,3),False)
+            msg.arm_feedback_current_motor_max_acc_limit.joint_motor_num = (
+                self.ConvertToNegative_8bit(
+                    self.ConvertBytesToInt(can_data, 0, 1), False
+                )
+            )
+            msg.arm_feedback_current_motor_max_acc_limit.max_joint_acc = (
+                self.ConvertToNegative_16bit(
+                    self.ConvertBytesToInt(can_data, 1, 3), False
+                )
+            )
         # 机械臂控制指令2,0x151
-        elif(can_id == CanIDPiper.ARM_MOTION_CTRL_2.value):
+        elif can_id == CanIDPiper.ARM_MOTION_CTRL_2.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_motion_ctrl_2.ctrl_mode = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,0,1),False)
-            msg.arm_motion_ctrl_2.move_mode = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,1,2),False)
-            msg.arm_motion_ctrl_2.move_spd_rate_ctrl = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,2,3),False)
-            msg.arm_motion_ctrl_2.mit_mode = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,3,4),False)
-            msg.arm_motion_ctrl_2.residence_time = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,4,5),False)
+            msg.arm_motion_ctrl_2.ctrl_mode = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 0, 1), False
+            )
+            msg.arm_motion_ctrl_2.move_mode = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 1, 2), False
+            )
+            msg.arm_motion_ctrl_2.move_spd_rate_ctrl = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 2, 3), False
+            )
+            msg.arm_motion_ctrl_2.mit_mode = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 3, 4), False
+            )
+            msg.arm_motion_ctrl_2.residence_time = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 4, 5), False
+            )
         # 读取主臂发送的目标joint数值
-        elif(can_id == CanIDPiper.ARM_JOINT_CTRL_12.value):
+        elif can_id == CanIDPiper.ARM_JOINT_CTRL_12.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_joint_ctrl.joint_1 = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,0,4))
-            msg.arm_joint_ctrl.joint_2 = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
-        elif(can_id == CanIDPiper.ARM_JOINT_CTRL_34.value):
+            msg.arm_joint_ctrl.joint_1 = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 0, 4)
+            )
+            msg.arm_joint_ctrl.joint_2 = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
+        elif can_id == CanIDPiper.ARM_JOINT_CTRL_34.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_joint_ctrl.joint_3 = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,0,4))
-            msg.arm_joint_ctrl.joint_4 = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
-        elif(can_id == CanIDPiper.ARM_JOINT_CTRL_56.value):
+            msg.arm_joint_ctrl.joint_3 = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 0, 4)
+            )
+            msg.arm_joint_ctrl.joint_4 = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
+        elif can_id == CanIDPiper.ARM_JOINT_CTRL_56.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_joint_ctrl.joint_5 = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,0,4))
-            msg.arm_joint_ctrl.joint_6 = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,4,8))
+            msg.arm_joint_ctrl.joint_5 = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 0, 4)
+            )
+            msg.arm_joint_ctrl.joint_6 = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 4, 8)
+            )
         # 夹爪
-        elif(can_id == CanIDPiper.ARM_GRIPPER_CTRL.value):
+        elif can_id == CanIDPiper.ARM_GRIPPER_CTRL.value:
             msg.type_ = ArmMessageMapping.get_mapping(can_id=can_id)
-            msg.arm_gripper_ctrl.grippers_angle = self.ConvertToNegative_32bit(self.ConvertBytesToInt(can_data,0,4))
-            msg.arm_gripper_ctrl.grippers_effort = self.ConvertToNegative_16bit(self.ConvertBytesToInt(can_data,4,6))
-            msg.arm_gripper_ctrl.status_code = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,6,7),False)
-            msg.arm_gripper_ctrl.set_zero = self.ConvertToNegative_8bit(self.ConvertBytesToInt(can_data,7,8),False)
+            msg.arm_gripper_ctrl.grippers_angle = self.ConvertToNegative_32bit(
+                self.ConvertBytesToInt(can_data, 0, 4)
+            )
+            msg.arm_gripper_ctrl.grippers_effort = self.ConvertToNegative_16bit(
+                self.ConvertBytesToInt(can_data, 4, 6)
+            )
+            msg.arm_gripper_ctrl.status_code = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 6, 7), False
+            )
+            msg.arm_gripper_ctrl.set_zero = self.ConvertToNegative_8bit(
+                self.ConvertBytesToInt(can_data, 7, 8), False
+            )
         else:
             ret = False
         return ret
 
-    def EncodeMessage(self, msg:PiperMessage, tx_can_frame: Optional[can.Message]):
+    def EncodeMessage(self, msg: PiperMessage, tx_can_frame: Optional[can.Message]):
         """将消息转为can数据帧
 
         Args:
@@ -257,120 +490,208 @@ class C_PiperParserV1(C_PiperParserBase):
 
                 msg消息的type若不存在, 反馈False
         """
-        ret:bool = True
+        ret: bool = True
         msg_type_ = msg.type_
         tx_can_frame.arbitration_id = ArmMessageMapping.get_mapping(msg_type=msg_type_)
-        if(msg_type_ == ArmMsgType.PiperMsgMotionCtrl_1):
-             
-            tx_can_frame.data = self.ConvertToList_8bit(msg.arm_motion_ctrl_1.emergency_stop,False) + \
-                                self.ConvertToList_8bit(msg.arm_motion_ctrl_1.track_ctrl,False) + \
-                                self.ConvertToList_8bit(msg.arm_motion_ctrl_1.grag_teach_ctrl,False) + \
-                                [0x00, 0x00, 0x00, 0x00, 0x00]
-        elif(msg_type_ == ArmMsgType.PiperMsgMotionCtrl_2):
-             
-            tx_can_frame.data = self.ConvertToList_8bit(msg.arm_motion_ctrl_2.ctrl_mode,False) + \
-                                self.ConvertToList_8bit(msg.arm_motion_ctrl_2.move_mode,False) + \
-                                self.ConvertToList_8bit(msg.arm_motion_ctrl_2.move_spd_rate_ctrl,False) + \
-                                self.ConvertToList_8bit(msg.arm_motion_ctrl_2.mit_mode,False) + \
-                                self.ConvertToList_8bit(msg.arm_motion_ctrl_2.residence_time,False) + \
-                                [0x00, 0x00, 0x00]
-        elif(msg_type_ == ArmMsgType.PiperMsgMotionCtrlCartesian_1):
-             
-            tx_can_frame.data = self.ConvertToList_32bit(msg.arm_motion_ctrl_cartesian.X_axis) + \
-                                self.ConvertToList_32bit(msg.arm_motion_ctrl_cartesian.Y_axis)
-        elif(msg_type_ == ArmMsgType.PiperMsgMotionCtrlCartesian_2):
-             
-            tx_can_frame.data = self.ConvertToList_32bit(msg.arm_motion_ctrl_cartesian.Z_axis) + \
-                                self.ConvertToList_32bit(msg.arm_motion_ctrl_cartesian.RX_axis)
-        elif(msg_type_ == ArmMsgType.PiperMsgMotionCtrlCartesian_3):
-             
-            tx_can_frame.data = self.ConvertToList_32bit(msg.arm_motion_ctrl_cartesian.RY_axis) + \
-                                self.ConvertToList_32bit(msg.arm_motion_ctrl_cartesian.RZ_axis)
-        elif(msg_type_ == ArmMsgType.PiperMsgJointCtrl_12):
-             
-            tx_can_frame.data = self.ConvertToList_32bit(msg.arm_joint_ctrl.joint_1) + \
-                                self.ConvertToList_32bit(msg.arm_joint_ctrl.joint_2)
-        elif(msg_type_ == ArmMsgType.PiperMsgJointCtrl_34):
-             
-            tx_can_frame.data = self.ConvertToList_32bit(msg.arm_joint_ctrl.joint_3) + \
-                                self.ConvertToList_32bit(msg.arm_joint_ctrl.joint_4)
-        elif(msg_type_ == ArmMsgType.PiperMsgJointCtrl_56):
-             
-            tx_can_frame.data = self.ConvertToList_32bit(msg.arm_joint_ctrl.joint_5) + \
-                                self.ConvertToList_32bit(msg.arm_joint_ctrl.joint_6)
-        elif(msg_type_ == ArmMsgType.PiperMsgCircularPatternCoordNumUpdateCtrl):
-             
-            tx_can_frame.data = self.ConvertToList_8bit(msg.arm_circular_ctrl.instruction_num,False) + \
-                                [0, 0, 0, 0, 0, 0, 0]
-        elif(msg_type_ == ArmMsgType.PiperMsgGripperCtrl):
-             
+        if msg_type_ == ArmMsgType.PiperMsgMotionCtrl_1:
+
+            tx_can_frame.data = (
+                self.ConvertToList_8bit(msg.arm_motion_ctrl_1.emergency_stop, False)
+                + self.ConvertToList_8bit(msg.arm_motion_ctrl_1.track_ctrl, False)
+                + self.ConvertToList_8bit(msg.arm_motion_ctrl_1.grag_teach_ctrl, False)
+                + [0x00, 0x00, 0x00, 0x00, 0x00]
+            )
+        elif msg_type_ == ArmMsgType.PiperMsgMotionCtrl_2:
+
+            tx_can_frame.data = (
+                self.ConvertToList_8bit(msg.arm_motion_ctrl_2.ctrl_mode, False)
+                + self.ConvertToList_8bit(msg.arm_motion_ctrl_2.move_mode, False)
+                + self.ConvertToList_8bit(
+                    msg.arm_motion_ctrl_2.move_spd_rate_ctrl, False
+                )
+                + self.ConvertToList_8bit(msg.arm_motion_ctrl_2.mit_mode, False)
+                + self.ConvertToList_8bit(msg.arm_motion_ctrl_2.residence_time, False)
+                + [0x00, 0x00, 0x00]
+            )
+        elif msg_type_ == ArmMsgType.PiperMsgMotionCtrlCartesian_1:
+
+            tx_can_frame.data = self.ConvertToList_32bit(
+                msg.arm_motion_ctrl_cartesian.X_axis
+            ) + self.ConvertToList_32bit(msg.arm_motion_ctrl_cartesian.Y_axis)
+        elif msg_type_ == ArmMsgType.PiperMsgMotionCtrlCartesian_2:
+
+            tx_can_frame.data = self.ConvertToList_32bit(
+                msg.arm_motion_ctrl_cartesian.Z_axis
+            ) + self.ConvertToList_32bit(msg.arm_motion_ctrl_cartesian.RX_axis)
+        elif msg_type_ == ArmMsgType.PiperMsgMotionCtrlCartesian_3:
+
+            tx_can_frame.data = self.ConvertToList_32bit(
+                msg.arm_motion_ctrl_cartesian.RY_axis
+            ) + self.ConvertToList_32bit(msg.arm_motion_ctrl_cartesian.RZ_axis)
+        elif msg_type_ == ArmMsgType.PiperMsgJointCtrl_12:
+
+            tx_can_frame.data = self.ConvertToList_32bit(
+                msg.arm_joint_ctrl.joint_1
+            ) + self.ConvertToList_32bit(msg.arm_joint_ctrl.joint_2)
+        elif msg_type_ == ArmMsgType.PiperMsgJointCtrl_34:
+
+            tx_can_frame.data = self.ConvertToList_32bit(
+                msg.arm_joint_ctrl.joint_3
+            ) + self.ConvertToList_32bit(msg.arm_joint_ctrl.joint_4)
+        elif msg_type_ == ArmMsgType.PiperMsgJointCtrl_56:
+
+            tx_can_frame.data = self.ConvertToList_32bit(
+                msg.arm_joint_ctrl.joint_5
+            ) + self.ConvertToList_32bit(msg.arm_joint_ctrl.joint_6)
+        elif msg_type_ == ArmMsgType.PiperMsgCircularPatternCoordNumUpdateCtrl:
+
+            tx_can_frame.data = self.ConvertToList_8bit(
+                msg.arm_circular_ctrl.instruction_num, False
+            ) + [0, 0, 0, 0, 0, 0, 0]
+        elif msg_type_ == ArmMsgType.PiperMsgGripperCtrl:
+
             # print(msg.arm_gripper_ctrl.grippers_angle)
-            tx_can_frame.data = self.ConvertToList_32bit(msg.arm_gripper_ctrl.grippers_angle) + \
-                                self.ConvertToList_16bit(msg.arm_gripper_ctrl.grippers_effort,False) + \
-                                self.ConvertToList_8bit(msg.arm_gripper_ctrl.status_code,False) + \
-                                self.ConvertToList_8bit(msg.arm_gripper_ctrl.set_zero,False)
-        elif(msg_type_ == ArmMsgType.PiperMsgMasterSlaveModeConfig):
-             
-            tx_can_frame.data = self.ConvertToList_8bit(msg.arm_ms_config.linkage_config,False) + \
-                                self.ConvertToList_8bit(msg.arm_ms_config.feedback_offset,False) + \
-                                self.ConvertToList_8bit(msg.arm_ms_config.ctrl_offset,False) + \
-                                self.ConvertToList_8bit(msg.arm_ms_config.linkage_offset,False) + \
-                                [0, 0, 0, 0]
-        elif(msg_type_ == ArmMsgType.PiperMsgMotorEnableDisableConfig):
-             
-            tx_can_frame.data = self.ConvertToList_8bit(msg.arm_motor_enable.motor_num,False) + \
-                                self.ConvertToList_8bit(msg.arm_motor_enable.enable_flag,False) + \
-                                [0, 0, 0, 0, 0, 0]
-        elif(msg_type_ == ArmMsgType.PiperMsgSearchMotorMaxAngleSpdAccLimit):
-             
-            tx_can_frame.data = self.ConvertToList_8bit(msg.arm_search_motor_max_angle_spd_acc_limit.motor_num,False) + \
-                                self.ConvertToList_8bit(msg.arm_search_motor_max_angle_spd_acc_limit.search_content,False) + \
-                                [0, 0, 0, 0, 0, 0]
-        elif(msg_type_ == ArmMsgType.PiperMsgMotorAngleLimitMaxSpdSet):
-             
-            tx_can_frame.data = self.ConvertToList_8bit(msg.arm_motor_angle_limit_max_spd_set.motor_num,False) + \
-                                self.ConvertToList_16bit(msg.arm_motor_angle_limit_max_spd_set.max_angle_limit) + \
-                                self.ConvertToList_16bit(msg.arm_motor_angle_limit_max_spd_set.min_angle_limit) + \
-                                self.ConvertToList_16bit(msg.arm_motor_angle_limit_max_spd_set.max_jonit_spd,False) + \
-                                [0]
-        elif(msg_type_ == ArmMsgType.PiperMsgJointConfig):
-             
-            tx_can_frame.data = self.ConvertToList_8bit(msg.arm_joint_config.joint_motor_num,False) + \
-                                self.ConvertToList_8bit(msg.arm_joint_config.set_motor_current_pos_as_zero,False) + \
-                                self.ConvertToList_8bit(msg.arm_joint_config.acc_param_config_is_effective_or_not,False) + \
-                                self.ConvertToList_16bit(msg.arm_joint_config.max_joint_acc,False) + \
-                                self.ConvertToList_8bit(msg.arm_joint_config.clear_joint_err,False) + \
-                                [0, 0]
-        elif(msg_type_ == ArmMsgType.PiperMsgInstructionResponseConfig):
-             
-            tx_can_frame.data = self.ConvertToList_8bit(msg.arm_set_instruction_response.instruction_index,False) + \
-                                self.ConvertToList_8bit(msg.arm_set_instruction_response.zero_config_success_flag,False) + \
-                                [0, 0, 0, 0, 0, 0]
-        elif(msg_type_ == ArmMsgType.PiperMsgParamEnquiryAndConfig):
-             
-            tx_can_frame.data = self.ConvertToList_8bit(msg.arm_param_enquiry_and_config.param_enquiry,False) + \
-                                self.ConvertToList_8bit(msg.arm_param_enquiry_and_config.param_setting,False) + \
-                                self.ConvertToList_8bit(msg.arm_param_enquiry_and_config.data_feedback_0x48x,False) + \
-                                self.ConvertToList_8bit(msg.arm_param_enquiry_and_config.end_load_param_setting_effective,False) + \
-                                self.ConvertToList_8bit(msg.arm_param_enquiry_and_config.set_end_load,False) + \
-                                [0, 0, 0]
-        elif(msg_type_ == ArmMsgType.PiperMsgEndVelAccParamConfig):
-             
-            tx_can_frame.data = self.ConvertToList_16bit(msg.arm_end_vel_acc_config.end_max_linear_vel,False) + \
-                                self.ConvertToList_16bit(msg.arm_end_vel_acc_config.end_max_angular_vel,False) + \
-                                self.ConvertToList_16bit(msg.arm_end_vel_acc_config.end_max_linear_acc,False) + \
-                                self.ConvertToList_16bit(msg.arm_end_vel_acc_config.end_max_angular_acc,False)
-        elif(msg_type_ == ArmMsgType.PiperMsgCrashProtectionRatingConfig):
-             
-            tx_can_frame.data = self.ConvertToList_8bit(msg.arm_crash_protection_rating_config.jonit_1_protection_level,False) + \
-                                self.ConvertToList_8bit(msg.arm_crash_protection_rating_config.jonit_2_protection_level,False) + \
-                                self.ConvertToList_8bit(msg.arm_crash_protection_rating_config.jonit_3_protection_level,False) + \
-                                self.ConvertToList_8bit(msg.arm_crash_protection_rating_config.jonit_4_protection_level,False) + \
-                                self.ConvertToList_8bit(msg.arm_crash_protection_rating_config.jonit_5_protection_level,False) + \
-                                self.ConvertToList_8bit(msg.arm_crash_protection_rating_config.jonit_6_protection_level,False) + \
-                                [0, 0]
+            tx_can_frame.data = (
+                self.ConvertToList_32bit(msg.arm_gripper_ctrl.grippers_angle)
+                + self.ConvertToList_16bit(msg.arm_gripper_ctrl.grippers_effort, False)
+                + self.ConvertToList_8bit(msg.arm_gripper_ctrl.status_code, False)
+                + self.ConvertToList_8bit(msg.arm_gripper_ctrl.set_zero, False)
+            )
+        elif msg_type_ == ArmMsgType.PiperMsgMasterSlaveModeConfig:
+
+            tx_can_frame.data = (
+                self.ConvertToList_8bit(msg.arm_ms_config.linkage_config, False)
+                + self.ConvertToList_8bit(msg.arm_ms_config.feedback_offset, False)
+                + self.ConvertToList_8bit(msg.arm_ms_config.ctrl_offset, False)
+                + self.ConvertToList_8bit(msg.arm_ms_config.linkage_offset, False)
+                + [0, 0, 0, 0]
+            )
+        elif msg_type_ == ArmMsgType.PiperMsgMotorEnableDisableConfig:
+
+            tx_can_frame.data = (
+                self.ConvertToList_8bit(msg.arm_motor_enable.motor_num, False)
+                + self.ConvertToList_8bit(msg.arm_motor_enable.enable_flag, False)
+                + [0, 0, 0, 0, 0, 0]
+            )
+        elif msg_type_ == ArmMsgType.PiperMsgSearchMotorMaxAngleSpdAccLimit:
+
+            tx_can_frame.data = (
+                self.ConvertToList_8bit(
+                    msg.arm_search_motor_max_angle_spd_acc_limit.motor_num, False
+                )
+                + self.ConvertToList_8bit(
+                    msg.arm_search_motor_max_angle_spd_acc_limit.search_content, False
+                )
+                + [0, 0, 0, 0, 0, 0]
+            )
+        elif msg_type_ == ArmMsgType.PiperMsgMotorAngleLimitMaxSpdSet:
+
+            tx_can_frame.data = (
+                self.ConvertToList_8bit(
+                    msg.arm_motor_angle_limit_max_spd_set.motor_num, False
+                )
+                + self.ConvertToList_16bit(
+                    msg.arm_motor_angle_limit_max_spd_set.max_angle_limit
+                )
+                + self.ConvertToList_16bit(
+                    msg.arm_motor_angle_limit_max_spd_set.min_angle_limit
+                )
+                + self.ConvertToList_16bit(
+                    msg.arm_motor_angle_limit_max_spd_set.max_jonit_spd, False
+                )
+                + [0]
+            )
+        elif msg_type_ == ArmMsgType.PiperMsgJointConfig:
+
+            tx_can_frame.data = (
+                self.ConvertToList_8bit(msg.arm_joint_config.joint_motor_num, False)
+                + self.ConvertToList_8bit(
+                    msg.arm_joint_config.set_motor_current_pos_as_zero, False
+                )
+                + self.ConvertToList_8bit(
+                    msg.arm_joint_config.acc_param_config_is_effective_or_not, False
+                )
+                + self.ConvertToList_16bit(msg.arm_joint_config.max_joint_acc, False)
+                + self.ConvertToList_8bit(msg.arm_joint_config.clear_joint_err, False)
+                + [0, 0]
+            )
+        elif msg_type_ == ArmMsgType.PiperMsgInstructionResponseConfig:
+
+            tx_can_frame.data = (
+                self.ConvertToList_8bit(
+                    msg.arm_set_instruction_response.instruction_index, False
+                )
+                + self.ConvertToList_8bit(
+                    msg.arm_set_instruction_response.zero_config_success_flag, False
+                )
+                + [0, 0, 0, 0, 0, 0]
+            )
+        elif msg_type_ == ArmMsgType.PiperMsgParamEnquiryAndConfig:
+
+            tx_can_frame.data = (
+                self.ConvertToList_8bit(
+                    msg.arm_param_enquiry_and_config.param_enquiry, False
+                )
+                + self.ConvertToList_8bit(
+                    msg.arm_param_enquiry_and_config.param_setting, False
+                )
+                + self.ConvertToList_8bit(
+                    msg.arm_param_enquiry_and_config.data_feedback_0x48x, False
+                )
+                + self.ConvertToList_8bit(
+                    msg.arm_param_enquiry_and_config.end_load_param_setting_effective,
+                    False,
+                )
+                + self.ConvertToList_8bit(
+                    msg.arm_param_enquiry_and_config.set_end_load, False
+                )
+                + [0, 0, 0]
+            )
+        elif msg_type_ == ArmMsgType.PiperMsgEndVelAccParamConfig:
+
+            tx_can_frame.data = (
+                self.ConvertToList_16bit(
+                    msg.arm_end_vel_acc_config.end_max_linear_vel, False
+                )
+                + self.ConvertToList_16bit(
+                    msg.arm_end_vel_acc_config.end_max_angular_vel, False
+                )
+                + self.ConvertToList_16bit(
+                    msg.arm_end_vel_acc_config.end_max_linear_acc, False
+                )
+                + self.ConvertToList_16bit(
+                    msg.arm_end_vel_acc_config.end_max_angular_acc, False
+                )
+            )
+        elif msg_type_ == ArmMsgType.PiperMsgCrashProtectionRatingConfig:
+
+            tx_can_frame.data = (
+                self.ConvertToList_8bit(
+                    msg.arm_crash_protection_rating_config.jonit_1_protection_level,
+                    False,
+                )
+                + self.ConvertToList_8bit(
+                    msg.arm_crash_protection_rating_config.jonit_2_protection_level,
+                    False,
+                )
+                + self.ConvertToList_8bit(
+                    msg.arm_crash_protection_rating_config.jonit_3_protection_level,
+                    False,
+                )
+                + self.ConvertToList_8bit(
+                    msg.arm_crash_protection_rating_config.jonit_4_protection_level,
+                    False,
+                )
+                + self.ConvertToList_8bit(
+                    msg.arm_crash_protection_rating_config.jonit_5_protection_level,
+                    False,
+                )
+                + self.ConvertToList_8bit(
+                    msg.arm_crash_protection_rating_config.jonit_6_protection_level,
+                    False,
+                )
+                + [0, 0]
+            )
         else:
             ret = False
         return ret
-            
-

--- a/protocol/protocol_v1/piper_protocol_v1.py
+++ b/protocol/protocol_v1/piper_protocol_v1.py
@@ -2,28 +2,17 @@
 # -*-coding:utf8-*-
 # 机械臂协议V1版本，为方便后续修改协议升级，继承自base
 
-from abc import ABC, abstractmethod
-import time
-from threading import Timer
-from enum import Enum, auto
 import can
-from can.message import Message
 
 from typing import (
     Optional,
 )
 
-# import sys,os
-# sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
 from ..piper_protocol_base import C_PiperParserBase
 
-# from ...protocol.piper_protocol_base import C_PiperParserBase
 from ...piper_msgs.msg_v1 import (
     ArmMsgType,
     PiperMessage,
-    ArmMsgStatus,
-    ArmMsgJointFeedBack,
-    ArmMsgGripperFeedBack,
     CanIDPiper,
     ArmMessageMapping,
 )


### PR DESCRIPTION
Applied the [black python code formatter](https://black.readthedocs.io/en/stable/) and removed all unused imports flagged up by my IDE.

No new code was added, despite the scary-looking summary of `+3,038 −1,848`. This is because `black` tries to adhere to a consistent line length and some parts of this code had mile-long lines. They aren't much prettier now but at least somewhat readable on average size screens.