### PR TITLE
Fix SyntaxWarning: invalid escape sequence '\[' in docstrings

### DIFF
--- a/piper_sdk/interface/piper_interface.py
+++ b/piper_sdk/interface/piper_interface.py
@@ -3252,7 +3252,7 @@ class C_PiperInterface():
                     acc_param_is_effective: Literal[0x00, 0xAE] = 0,
                     max_joint_acc: int = 500,
                     clear_err: Literal[0x00, 0xAE] = 0):
-        '''
+        r'''
         关节设置
         
         CAN ID:
@@ -3268,7 +3268,7 @@ class C_PiperInterface():
                            输入范围\[0, 500\]-->[0 rad/s^2, 5.0 rad/s^2]
             clear_joint_err: 清除关节错误代码,有效值,0xAE
         '''
-        '''
+        r'''
         Joint Configuration Command
         
         CAN ID:

--- a/piper_sdk/interface/piper_interface_v2.py
+++ b/piper_sdk/interface/piper_interface_v2.py
@@ -3252,7 +3252,7 @@ class C_PiperInterface_V2():
                     acc_param_is_effective: Literal[0x00, 0xAE] = 0,
                     max_joint_acc: int = 500,
                     clear_err: Literal[0x00, 0xAE] = 0):
-        '''
+        r'''
         关节设置
         
         CAN ID:
@@ -3268,7 +3268,7 @@ class C_PiperInterface_V2():
                            输入范围\[0, 500\]-->[0 rad/s^2, 5.0 rad/s^2]
             clear_joint_err: 清除关节错误代码,有效值,0xAE
         '''
-        '''
+        r'''
         Joint Configuration Command
         
         CAN ID:

--- a/piper_sdk/piper_msgs/msg_v2/transmit/arm_joint_config.py
+++ b/piper_sdk/piper_msgs/msg_v2/transmit/arm_joint_config.py
@@ -4,7 +4,7 @@ from typing_extensions import (
     Literal,
 )
 class ArmMsgJointConfig:
-    '''
+    r'''
     msg_v2_transmit
     
     关节设置指令
@@ -32,7 +32,7 @@ class ArmMsgJointConfig:
         Byte 6: 保留
         Byte 7: 保留
     '''
-    '''
+    r'''
     msg_v2_transmit
     
     Joint Configuration Command


### PR DESCRIPTION
## Summary

Three docstrings contain literal `\[` / `\]` (visible-bracket escaping intended for Markdown-like rendering of the `\[0, 500\]-->[0 rad/s^2, 5.0 rad/s^2]` ranges). Because they live inside plain `'''...'''` string literals, Python 3.12 emits `SyntaxWarning: invalid escape sequence '\['` whenever the SDK is imported, and Python 3.13+ promotes these to `SyntaxError`.

The minimal fix is to mark the affected docstrings as raw strings (`r'''...'''`). The on-disk byte content of the docstrings is unchanged, so any downstream tooling that reads `__doc__` sees the same text.

### Reproduction (before)

```
$ python -c "import piper_sdk"
.../piper_sdk/piper_msgs/msg_v2/transmit/arm_joint_config.py:7: SyntaxWarning: invalid escape sequence '\['
.../piper_sdk/piper_msgs/msg_v2/transmit/arm_joint_config.py:35: SyntaxWarning: invalid escape sequence '\['
.../piper_sdk/interface/piper_interface.py:3255: SyntaxWarning: invalid escape sequence '\['
.../piper_sdk/interface/piper_interface.py:3271: SyntaxWarning: invalid escape sequence '\['
.../piper_sdk/interface/piper_interface_v2.py:3255: SyntaxWarning: invalid escape sequence '\['
.../piper_sdk/interface/piper_interface_v2.py:3271: SyntaxWarning: invalid escape sequence '\['
```

### After

No warnings on import. Verified with:

```python
import warnings, pathlib
for p in pathlib.Path('piper_sdk').rglob('*.py'):
    with warnings.catch_warnings(record=True) as w:
        warnings.simplefilter('always')
        compile(p.read_text(encoding='utf-8'), str(p), 'exec')
        assert not [x for x in w if issubclass(x.category, SyntaxWarning)], p
```

### Files touched

- `piper_sdk/piper_msgs/msg_v2/transmit/arm_joint_config.py` — class docstring (CN + EN)
- `piper_sdk/interface/piper_interface.py` — `JointConfig` method docstrings (CN + EN)
- `piper_sdk/interface/piper_interface_v2.py` — `JointConfig` method docstrings (CN + EN)

Six characters changed (`'''` → `r'''`); no behavioural change.

## Test plan

- [x] `import piper_sdk` produces no SyntaxWarning under Python 3.12
- [x] `compile()` over every `.py` in `piper_sdk/` produces zero SyntaxWarnings
- [x] `git diff` is exactly six `'''` → `r'''` substitutions